### PR TITLE
Before exporting images, change the background to transparent

### DIFF
--- a/avogadro/avogadro.cpp
+++ b/avogadro/avogadro.cpp
@@ -41,9 +41,14 @@ int main(int argc, char *argv[])
                              "This system does not support OpenGL!");
     return 1;
   }
+
+  // Use high-resolution (e.g., 2x) icons if available
+  app.setAttribute(Qt::AA_UseHighDpiPixmaps);
+
   // Set up the default format for our GL contexts.
   QGLFormat defaultFormat = QGLFormat::defaultFormat();
   defaultFormat.setSampleBuffers(true);
+  defaultFormat.setAlpha(true);
   QGLFormat::setDefaultFormat(defaultFormat);
 
   QStringList fileNames;

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -940,11 +940,29 @@ void MainWindow::exportGraphics()
     fileName += ".png";
 
   // render it (with alpha channel)
+  Rendering::Scene *scene(NULL);
+  GLWidget *viewWidget(NULL);
+  EditGLWidget *editWidget(NULL);
+  if ((viewWidget = qobject_cast<GLWidget*>(m_multiViewWidget->activeWidget()))) {
+    scene = &viewWidget->renderer().scene();
+  }
+  else if ((editWidget =
+           qobject_cast<EditGLWidget*>(m_multiViewWidget->activeWidget()))) {
+    scene = &editWidget->renderer().scene();
+  }
+  Vector4ub cColor = scene->backgroundColor();
+  unsigned char alpha = cColor[3];
+  cColor[3] = 0; // 100% transparent for export
+  scene->setBackgroundColor(cColor);
+
   QImage exportImage;
   glWidget->raise();
   glWidget->repaint();
   if (QGLFramebufferObject::hasOpenGLFramebufferObjects()) {
-    exportImage = glWidget->grabFrameBuffer(true);
+    // by using renderPixmap, we can scale the export size arbitrarily
+    unsigned int scale = 2;
+    QPixmap pixmap = glWidget->renderPixmap( glWidget->width()*scale, glWidget->height()*scale );
+    exportImage = pixmap.toImage();
   }
   else {
     QPixmap pixmap = QPixmap::grabWindow(glWidget->winId());
@@ -963,8 +981,12 @@ void MainWindow::exportGraphics()
   if (!exportImage.save(fileName)) {
     QMessageBox::warning(this, tr("Avogadro"),
                          tr("Cannot save file %1.").arg(fileName));
-    return;
   }
+
+  // set the GL widget back to the right background color (i.e., not 100% transparent)
+  cColor[3] = alpha; // previous color
+  scene->setBackgroundColor(cColor);
+  glWidget->repaint();
 }
 
 void MainWindow::reassignCustomElements()


### PR DESCRIPTION
Also enables scaling exported graphics (x2 by default).
Unfortunately, gives a "flash" when the background changes, but
I'm not sure how (or if) to stop this (it indicates a snapshot).

Change-Id: Idcb72b1a395f779cab0d58b94d4f4b0a112d3ad0
