### PR TITLE
Fix link error when testing is enabled

### DIFF
--- a/avogadro/CMakeLists.txt
+++ b/avogadro/CMakeLists.txt
@@ -95,6 +95,7 @@ else()
   set_target_properties(avogadro PROPERTIES OUTPUT_NAME "avogadro2")
 endif()
 if(ENABLE_TESTING)
+  find_package(Qt5Test REQUIRED)
   target_link_libraries(avogadro QtTesting)
 endif()
 install(TARGETS avogadro


### PR DESCRIPTION
The Qt5::Test is an exported target in modern CMake, so we must ensure
that Qt5Test is now found before linking in order to avoid a link error.
