### PR TITLE
Tabify the "Display Types" and "View" docks and hide file bar on Mac

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -315,6 +315,8 @@ void MainWindow::setupInterface()
   // Our view dock.
   m_viewDock = new QDockWidget(tr("View Configuration"), this);
   addDockWidget(Qt::LeftDockWidgetArea, m_viewDock);
+  // put display types on top of view config
+  tabifyDockWidget(m_viewDock, sceneDock);
 
   // Our molecule dock.
   QDockWidget *moleculeDock = new QDockWidget(tr("Molecules"), this);
@@ -1422,6 +1424,11 @@ void MainWindow::buildMenu()
   connect(m_redo, SIGNAL(triggered()), SLOT(redoEdit()));
   m_menuBuilder->addAction(editPath, m_undo, 1);
   m_menuBuilder->addAction(editPath, m_redo, 0);
+
+#ifdef Q_OS_MAC
+  // hide the file toolbar on Mac
+  m_fileToolBar->hide();
+#endif
 
   // View menu
   QStringList viewPath;


### PR DESCRIPTION
Minimize the number of left dock panels

Change-Id: I728e2aad56ed14cd5f4cdcc5967ab172e6050807