### PR TITLE
Make sure to populate the tool settings widget when switching tools.

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -1149,6 +1149,10 @@ void MainWindow::setActiveTool(QString toolName)
       if (toolPlugin->objectName() == toolName) {
         toolPlugin->activateAction()->triggered();
         glWidget->setActiveTool(toolPlugin);
+
+        // update the settings widget
+        m_toolDock->setWidget(toolPlugin->toolWidget());
+        m_toolDock->setWindowTitle(toolPlugin->activateAction()->text());
       }
     }
   }


### PR DESCRIPTION
Bug showed most clearly at launch, with an empty panel.

Change-Id: Iea180749c094d143a4903cd328054217073afbe1