### PR TITLE
Fix activation for render/molecule tree view widgets

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -347,6 +347,8 @@ void MainWindow::setupInterface()
   m_sceneTreeView->header()->setVisible(false);
   connect(m_sceneTreeView, SIGNAL(activated(QModelIndex)),
           SLOT(sceneItemActivated(QModelIndex)));
+  connect(m_sceneTreeView, SIGNAL(clicked(QModelIndex)),
+          SLOT(sceneItemActivated(QModelIndex)));
 
   // Create the molecule model
   m_moleculeModel = new QtGui::MoleculeModel(this);
@@ -359,6 +361,8 @@ void MainWindow::setupInterface()
   m_moleculeTreeView->header()->setSectionResizeMode(1, QHeaderView::Fixed);
   m_moleculeTreeView->header()->resizeSection(1, 30);
   connect(m_moleculeTreeView, SIGNAL(activated(QModelIndex)),
+          SLOT(moleculeActivated(QModelIndex)));
+  connect(m_moleculeTreeView, SIGNAL(clicked(QModelIndex)),
           SLOT(moleculeActivated(QModelIndex)));
 
   viewActivated(glWidget);


### PR DESCRIPTION
Mac evidently does not send activate() signal after clicking.
Now clicking on a row will properly activate.