### PR TITLE
Find Qt5 OpenGL component to fix linking error

### DIFF
--- a/avogadro/CMakeLists.txt
+++ b/avogadro/CMakeLists.txt
@@ -16,7 +16,7 @@ if(MSVC)
 endif()
 
 # Find the Qt components we need.
-find_package(Qt5 COMPONENTS Widgets Network REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Network OpenGL REQUIRED)
 
 configure_file(avogadroappconfig.h.in avogadroappconfig.h)
 


### PR DESCRIPTION
I encounter the following linking error without this change:

CMake Error at avogadro/CMakeLists.txt:89 (add_executable):
  Target "avogadro" links to target "Qt5::OpenGL" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?

CMake Error at avogadro/CMakeLists.txt:89 (add_executable):
  Target "avogadro" links to target "Qt5::OpenGL" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?

-- Generating done
-- Build files have been written to: /home/patrick/src/openchemistry/build/avogadroapp
CMakeFiles/avogadroapp.dir/build.make:107: recipe for target 'avogadroapp-prefix/src/avogadroapp-stamp/avogadroapp-configure' failed
make[2]: *** [avogadroapp-prefix/src/avogadroapp-stamp/avogadroapp-configure] Error 1
CMakeFiles/Makefile2:104: recipe for target 'CMakeFiles/avogadroapp.dir/all' failed
make[1]: *** [CMakeFiles/avogadroapp.dir/all] Error 2