### PR TITLE
Use toLocal8Bit over toStdString for file names

### DIFF
--- a/avogadro/backgroundfileformat.cpp
+++ b/avogadro/backgroundfileformat.cpp
@@ -46,7 +46,8 @@ void BackgroundFileFormat::read()
     m_error = tr("No file name set in BackgroundFileFormat!");
 
   if (m_error.isEmpty()) {
-    m_success = m_format->readFile(m_fileName.toStdString(), *m_molecule);
+    m_success = m_format->readFile(m_fileName.toLocal8Bit().data(),
+                                   *m_molecule);
 
     if (!m_success)
       m_error = QString::fromStdString(m_format->error());
@@ -70,7 +71,8 @@ void BackgroundFileFormat::write()
     m_error = tr("No file name set in BackgroundFileFormat!");
 
   if (m_error.isEmpty()) {
-    m_success = m_format->writeFile(m_fileName.toStdString(), *m_molecule);
+    m_success = m_format->writeFile(m_fileName.toLocal8Bit().data(),
+                                    *m_molecule);
 
     if (!m_success)
       m_error = QString::fromStdString(m_format->error());

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -580,7 +580,7 @@ bool MainWindow::openFile(const QString& fileName, Io::FileFormat* reader)
   if (m_fileReadMolecule)
     m_fileReadMolecule->deleteLater();
   m_fileReadMolecule = new Molecule(this);
-  m_fileReadMolecule->setData("fileName", fileName.toStdString());
+  m_fileReadMolecule->setData("fileName", fileName.toLocal8Bit().data());
   m_threadedReader->moveToThread(m_fileReadThread);
   m_threadedReader->setMolecule(m_fileReadMolecule);
   m_threadedReader->setFileName(fileName);
@@ -614,7 +614,7 @@ void MainWindow::backgroundReaderFinished()
     delete m_fileReadMolecule;
   } else if (m_threadedReader->success()) {
     if (!fileName.isEmpty()) {
-      m_fileReadMolecule->setData("fileName", fileName.toStdString());
+      m_fileReadMolecule->setData("fileName", fileName.toLocal8Bit().data());
       m_recentFiles.prepend(fileName);
       updateRecentFiles();
     } else {
@@ -654,7 +654,8 @@ bool MainWindow::backgroundWriterFinished()
   if (!m_progressDialog->wasCanceled()) {
     if (m_threadedWriter->success()) {
       statusBar()->showMessage(tr("File written: %1").arg(fileName));
-      m_threadedWriter->molecule()->setData("fileName", fileName.toStdString());
+      m_threadedWriter->molecule()->setData("fileName",
+                                            fileName.toLocal8Bit().data());
       markMoleculeClean();
       updateWindowTitle();
       success = true;


### PR DESCRIPTION
This is a change in Qt 5 that causes issues with non-Latin characters in
file names, using the local 8 bit encoding should work as expected.