### PR TITLE
Support fileOpen events on Mac with a QApplication subclass

### DIFF
--- a/avogadro/CMakeLists.txt
+++ b/avogadro/CMakeLists.txt
@@ -22,6 +22,7 @@ configure_file(avogadroappconfig.h.in avogadroappconfig.h)
 
 set(avogadro_srcs
   aboutdialog.cpp
+  application.cpp
   avogadro.cpp
   backgroundfileformat.cpp
   mainwindow.cpp

--- a/avogadro/application.cpp
+++ b/avogadro/application.cpp
@@ -62,13 +62,12 @@ bool Application::loadFile(const QString& fileName)
   }
 
   // if not, need to make this spawn a new instance
-  if (!window)
-  {
+  if (!window) {
     qDebug() << " don't have a window! ";
     return false;
   }
 
-  if (!const_cast<MainWindow*>(window)->openFile(fileName) ) {
+  if (!const_cast<MainWindow*>(window)->openFile(fileName)) {
     qDebug() << " failed to open through MainWindow";
     return false;
   }

--- a/avogadro/application.cpp
+++ b/avogadro/application.cpp
@@ -1,0 +1,79 @@
+/**********************************************************************
+This source file is part of the Avogadro project.
+
+Copyright (C) 2018 by Geoffrey R. Hutchison
+
+This source code is released under the New BSD License, (the "License").
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This file is part of the Avogadro molecular editor project.
+For more information, see <http://avogadro.cc/>
+ ***********************************************************************/
+
+#include "application.h"
+#include "mainwindow.h"
+
+#include <avogadro/io/fileformat.h>
+#include <avogadro/io/fileformatmanager.h>
+#include <avogadro/qtgui/fileformatdialog.h>
+
+#include <QtGui/QFileOpenEvent>
+#include <QtGui/QWindow>
+
+#include <QDebug>
+
+namespace Avogadro {
+
+Application::Application(int& argc, char** argv)
+  : QApplication(argc, argv)
+{}
+
+// Handle open events (e.g., Mac OS X open files)
+bool Application::event(QEvent* event)
+{
+  switch (event->type()) {
+    case QEvent::FileOpen:
+      return loadFile(static_cast<QFileOpenEvent*>(event)->file());
+    default:
+      return QGuiApplication::event(event);
+  }
+}
+
+bool Application::loadFile(const QString& fileName)
+{
+  if (fileName.isEmpty()) {
+    return false;
+  }
+
+  qDebug() << " trying to open " << fileName;
+
+  // check to see if we already have an open window
+  // (we'll let MainWindow handle the real work)
+  const MainWindow* window = NULL;
+  foreach (const QWidget* item, topLevelWidgets()) {
+    window = qobject_cast<const MainWindow*>(item);
+    if (window)
+      break;
+  }
+
+  // if not, need to make this spawn a new instance
+  if (!window)
+  {
+    qDebug() << " don't have a window! ";
+    return false;
+  }
+
+  if (!const_cast<MainWindow*>(window)->openFile(fileName) ) {
+    qDebug() << " failed to open through MainWindow";
+    return false;
+  }
+
+  return true;
+}
+
+} // end namespace Avogadro

--- a/avogadro/application.h
+++ b/avogadro/application.h
@@ -1,0 +1,40 @@
+/**********************************************************************
+  This source file is part of the Avogadro project.
+
+  Copyright (C) 2018 by Geoffrey R. Hutchison
+
+  This source code is released under the New BSD License, (the "License").
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.cc/>
+ ***********************************************************************/
+
+#ifndef AVOGADRO_APPLICATION_H
+#define AVOGADRO_APPLICATION_H
+
+#include <QtWidgets/QApplication>
+
+namespace Avogadro {
+
+  class Application : public QApplication
+  {
+    Q_OBJECT
+
+    public:
+      Application(int &argc, char **argv);
+      bool loadFile(const QString &fileName);
+
+  protected:
+      bool event(QEvent *event);
+
+  private:
+  };
+
+} // end namespace Avogadro
+#endif

--- a/avogadro/application.h
+++ b/avogadro/application.h
@@ -22,19 +22,19 @@
 
 namespace Avogadro {
 
-  class Application : public QApplication
-  {
-    Q_OBJECT
+class Application : public QApplication
+{
+  Q_OBJECT
 
-    public:
-      Application(int &argc, char **argv);
-      bool loadFile(const QString &fileName);
+public:
+  Application(int& argc, char** argv);
+  bool loadFile(const QString& fileName);
 
-  protected:
-      bool event(QEvent *event);
+protected:
+  bool event(QEvent* event);
 
-  private:
-  };
+private:
+};
 
 } // end namespace Avogadro
 #endif

--- a/avogadro/avogadro.cpp
+++ b/avogadro/avogadro.cpp
@@ -21,6 +21,7 @@
 #include <QtWidgets/QMessageBox>
 
 #include "mainwindow.h"
+#include "application.h"
 
 #ifdef Q_OS_MAC
 void removeMacSpecificMenuItems();
@@ -48,7 +49,7 @@ int main(int argc, char* argv[])
   QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
 #endif
 
-  QApplication app(argc, argv);
+  Avogadro::Application app(argc, argv);
 
   // Check for valid OpenGL support.
   auto offscreen = new QOffscreenSurface;

--- a/avogadro/avogadro.cpp
+++ b/avogadro/avogadro.cpp
@@ -20,8 +20,8 @@
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMessageBox>
 
-#include "mainwindow.h"
 #include "application.h"
+#include "mainwindow.h"
 
 #ifdef Q_OS_MAC
 void removeMacSpecificMenuItems();

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -567,10 +567,20 @@ void MainWindow::importFile()
 
 bool MainWindow::openFile(const QString& fileName, Io::FileFormat* reader)
 {
-  if (fileName.isEmpty() || reader == nullptr) {
+  if (fileName.isEmpty()) {
     delete reader;
     return false;
   }
+
+  if (reader == nullptr) {
+    const Io::FileFormat *format = QtGui::FileFormatDialog::findFileFormat(
+      this, tr("Select file reader"), fileName, FileFormat::File | FileFormat::Read,
+      "Avogadro:");
+    if (format)
+      reader = format->newInstance();
+  }
+  if (!reader)
+    return false;
 
   QString ident = QString::fromStdString(reader->identifier());
 

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -95,7 +95,8 @@ class XMLEventObserver : public pqEventObserver
   QString XMLString;
 
 public:
-  XMLEventObserver(QObject* p) : pqEventObserver(p)
+  XMLEventObserver(QObject* p)
+    : pqEventObserver(p)
   {
     this->XMLStream = nullptr;
   }
@@ -142,7 +143,11 @@ class XMLEventSource : public pqEventSource
   QXmlStreamReader* XMLStream;
 
 public:
-  XMLEventSource(QObject* p) : Superclass(p) { this->XMLStream = nullptr; }
+  XMLEventSource(QObject* p)
+    : Superclass(p)
+  {
+    this->XMLStream = nullptr;
+  }
   ~XMLEventSource() { delete this->XMLStream; }
 
 protected:
@@ -182,11 +187,11 @@ protected:
 };
 #endif
 
-using std::string;
-using std::vector;
 using Io::FileFormat;
 using Io::FileFormatManager;
 using QtGui::CustomElementDialog;
+using QtGui::ExtensionPlugin;
+using QtGui::ExtensionPluginFactory;
 using QtGui::FileFormatDialog;
 using QtGui::Molecule;
 using QtGui::RWMolecule;
@@ -195,23 +200,33 @@ using QtGui::ScenePluginFactory;
 using QtGui::ScenePluginModel;
 using QtGui::ToolPlugin;
 using QtGui::ToolPluginFactory;
-using QtGui::ExtensionPlugin;
-using QtGui::ExtensionPluginFactory;
 using QtOpenGL::GLWidget;
 using QtPlugins::PluginManager;
+using std::string;
+using std::vector;
 #ifdef AVO_USE_VTK
 using VTK::vtkGLWidget;
 #endif
 
 MainWindow::MainWindow(const QStringList& fileNames, bool disableSettings)
-  : m_molecule(nullptr), m_rwMolecule(nullptr), m_moleculeModel(nullptr),
-    m_queuedFilesStarted(false), m_menuBuilder(new MenuBuilder),
-    m_fileReadThread(nullptr), m_fileWriteThread(nullptr),
-    m_threadedReader(nullptr), m_threadedWriter(nullptr),
-    m_progressDialog(nullptr), m_fileReadMolecule(nullptr),
-    m_fileToolBar(new QToolBar(this)), m_toolToolBar(new QToolBar(this)),
-    m_moleculeDirty(false), m_undo(nullptr), m_redo(nullptr),
-    m_viewFactory(new ViewFactory), m_ui(new Ui::MainWindow)
+  : m_molecule(nullptr)
+  , m_rwMolecule(nullptr)
+  , m_moleculeModel(nullptr)
+  , m_queuedFilesStarted(false)
+  , m_menuBuilder(new MenuBuilder)
+  , m_fileReadThread(nullptr)
+  , m_fileWriteThread(nullptr)
+  , m_threadedReader(nullptr)
+  , m_threadedWriter(nullptr)
+  , m_progressDialog(nullptr)
+  , m_fileReadMolecule(nullptr)
+  , m_fileToolBar(new QToolBar(this))
+  , m_toolToolBar(new QToolBar(this))
+  , m_moleculeDirty(false)
+  , m_undo(nullptr)
+  , m_redo(nullptr)
+  , m_viewFactory(new ViewFactory)
+  , m_ui(new Ui::MainWindow)
 {
   m_ui->setupUi(this);
 
@@ -394,7 +409,7 @@ void MainWindow::newMolecule()
   setMolecule(new Molecule(this));
 }
 
-template <class T, class M>
+template<class T, class M>
 void setWidgetMolecule(T* glWidget, M* mol)
 {
   glWidget->setMolecule(mol);
@@ -573,9 +588,9 @@ bool MainWindow::openFile(const QString& fileName, Io::FileFormat* reader)
   }
 
   if (reader == nullptr) {
-    const Io::FileFormat *format = QtGui::FileFormatDialog::findFileFormat(
-      this, tr("Select file reader"), fileName, FileFormat::File | FileFormat::Read,
-      "Avogadro:");
+    const Io::FileFormat* format = QtGui::FileFormatDialog::findFileFormat(
+      this, tr("Select file reader"), fileName,
+      FileFormat::File | FileFormat::Read, "Avogadro:");
     if (format)
       reader = format->newInstance();
   }
@@ -708,9 +723,7 @@ void MainWindow::toolActivated()
   }
 }
 
-void MainWindow::viewConfigActivated()
-{
-}
+void MainWindow::viewConfigActivated() {}
 
 void MainWindow::rendererInvalid()
 {
@@ -781,7 +794,7 @@ bool populatePluginModel(ScenePluginModel& model, bool editOnly = false)
   return true;
 }
 
-template <class T>
+template<class T>
 bool populateTools(T* glWidget)
 {
   if (!glWidget->tools().isEmpty())
@@ -1604,8 +1617,8 @@ QString MainWindow::generateFilterString(
 
   // Create a map that groups the file extensions by name:
   QMap<QString, QString> formatMap;
-  for (vector<const FileFormat *>::const_iterator it = formats.begin(),
-                                                  itEnd = formats.end();
+  for (vector<const FileFormat*>::const_iterator it = formats.begin(),
+                                                 itEnd = formats.end();
        it != itEnd; ++it) {
     QString name(QString::fromStdString((*it)->name()));
     vector<string> exts = (*it)->fileExtensions();

--- a/avogadro/mainwindow.h
+++ b/avogadro/mainwindow.h
@@ -90,6 +90,12 @@ public slots:
    */
   void updateWindowTitle();
 
+  /**
+   * Use the FileFormat @a reader to load @a fileName. This method
+   * takes ownership of @a reader and will delete it before returning.
+   */
+  bool openFile(const QString& fileName, Io::FileFormat* reader = nullptr);
+
 #ifdef QTTESTING
   void playTest(const QString& fileName, bool exit = true);
 #endif
@@ -141,12 +147,6 @@ protected slots:
    * Import a file, using the full selection of formats capable of reading.
    */
   void importFile();
-
-  /**
-   * Use the FileFormat @a reader to load @a fileName. This method
-   * takes ownership of @a reader and will delete it before returning.
-   */
-  bool openFile(const QString& fileName, Io::FileFormat* reader);
 
   /**
    * Open file in the recent files list.


### PR DESCRIPTION
On MacOS, double-click from the Finder is handled by Qt
using events. This ports the Application class from Avo1
to handle drag-to-icon or double-click events.