### PR TITLE
Adding "Education" category

### DIFF
--- a/avogadro/icons/avogadro2.desktop
+++ b/avogadro/icons/avogadro2.desktop
@@ -6,6 +6,6 @@ Exec=avogadro2 %f
 Icon=avogadro2
 Terminal=false
 Type=Application
-Categories=Qt;Science;Chemistry;Physics;
+Categories=Qt;Science;Chemistry;Physics;Education;
 StartupNotify=true
 MimeType=chemical/x-cml;chemical/x-xyz;


### PR DESCRIPTION
Hi,

This desktop configuration file is one of the best I've seen among cross-distro projects, but not all Linux desktop environments have a "Science" category (or submenu) in their application menu, the most notable example being Cinnamon, the default desktop environment of Linux Mint (which is one of the most popular Linux distros). They do often have an Education category, however, so I thought that maybe adding the "Education" category to the desktop configuration file might help users of these desktop environments find it. 

Thanks for your time and your great work in making high-quality chemistry software more available to the masses,
Brenton