### PR TITLE
Add the logic to install the style plugins

### DIFF
--- a/cmake/DeployQt5.cmake
+++ b/cmake/DeployQt5.cmake
@@ -328,8 +328,18 @@ function(install_qt5_executable executable)
       install_qt5_plugin("${loc}" "${executable}" 0 installed_plugin_paths
         "PlugIns" "${component}")
       list(APPEND libs ${installed_plugin_paths})
+      get_property(loc TARGET Qt5::QMacStylePlugin
+        PROPERTY LOCATION_RELEASE)
+      install_qt5_plugin("${loc}" "${executable}" 0 installed_plugin_paths
+        "PlugIns" "${component}")
+      list(APPEND libs ${installed_plugin_paths})
     elseif(WIN32)
       get_property(loc TARGET Qt5::QWindowsIntegrationPlugin
+        PROPERTY LOCATION_RELEASE)
+      install_qt5_plugin("${loc}" "${executable}" 0 installed_plugin_paths
+        "" "${component}")
+      list(APPEND libs ${installed_plugin_paths})
+      get_property(loc TARGET Qt5::QWindowsVistaStylePlugin
         PROPERTY LOCATION_RELEASE)
       install_qt5_plugin("${loc}" "${executable}" 0 installed_plugin_paths
         "" "${component}")


### PR DESCRIPTION
This became necessary after Qt 5.9, making packages a little more
tedious to create. This should ensure packages have the appropriate
style available and don't look like 90s retro version fallbacks...