### PR TITLE
Updating mainwindow.cpp fixes avogadrolibs/#394

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -436,7 +436,7 @@ void MainWindow::setMolecule(Molecule* mol)
 
   // If the molecule is empty, make the editor active. Otherwise, use the
   // navigator tool.
-  if (m_molecule) {
+  if (!m_molecule) {
     QString targetToolName =
       m_molecule->atomCount() > 0 ? "Navigator" : "Editor";
     setActiveTool(targetToolName);


### PR DESCRIPTION
https://github.com/OpenChemistry/avogadrolibs/issues/394

**Change default tool to navigation, if the cartesian editor is used to add atoms** #394

comment by @ghutchis explaining the issue:
> I think I’d make a more specific use case - if file is empty, then switch to the navigation tool.
> 
> Use case:
> 
>     * User starts with something, uses Cartesian Editor to tweak - keep whatever tool was used before
> 
>     * User starts with empty file, pastes in Cartesians - switch to navigate tool
> 
> 
> Does that seem reasonable?

