### PR TITLE
Make sure to install Qt image plugins on Mac and Windows

### DIFF
--- a/avogadro/lastinstall/CMakeLists.txt
+++ b/avogadro/lastinstall/CMakeLists.txt
@@ -38,6 +38,15 @@ if((APPLE OR WIN32) AND NOT ${CMAKE_VERSION} VERSION_LESS 2.8.8)
     get_property(location TARGET ${plugin} PROPERTY LOCATION)
     list(APPEND plugins ${location})
   endforeach()
+  # make sure to include the core image formats
+  # likely only be required on Mac / Windows since Qt package on Unix provides
+  if((APPLE OR WIN32)
+    # JPG BMP, WebP, GIF plus default of PNG, etc.
+    foreach(qt_plugin Qt5::QJpegPlugin Qt5::QWbmpPlugin Qt5::QWebpPlugin Qt5::QGifPlugin)
+      get_property(location TARGET ${qt_plugin} PROPERTY LOCATION_RELEASE)
+      list(APPEND plugins ${location})
+    endforeach()
+  endif()
 
   # Find and fixup the Open Babel plugins (if installed)
   find_program(OBABEL_EXE obabel)


### PR DESCRIPTION
Fixes problems saving AVI (which uses JPG) on Mac at least

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
