### PR TITLE
Add .cjson extension if a filename has no extension on save.

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -1262,6 +1262,11 @@ bool MainWindow::saveFile(bool async)
   QString extension =
     QFileInfo(QString::fromStdString(fileName)).suffix().toLower();
 
+  if (extension.isEmpty()) {
+    fileName += ".cjson";
+    extension = QLatin1String("cjson");
+  }
+
   // Was the original format standard, or imported?
   if (extension == QLatin1String("cml")) {
     return saveFileAs(QString::fromStdString(fileName), new Io::CmlFormat,
@@ -1331,7 +1336,7 @@ bool MainWindow::saveFileAs(bool async)
   else if (extension == "cml")
     writer = new Io::CmlFormat;
   if (extension.isEmpty())
-    fileName += ".cml";
+    fileName += ".cjson";
 
   return saveFileAs(fileName, writer, async);
 }


### PR DESCRIPTION
In some cases Qt on Linux seems to allow files w/o extensions

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
