### PR TITLE
Add support for signing the app before generating DMG

### DIFF
--- a/cmake/AvogadroCPack.cmake
+++ b/cmake/AvogadroCPack.cmake
@@ -4,7 +4,7 @@ set(CPACK_PACKAGE_VERSION_MINOR ${AvogadroApp_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${AvogadroApp_VERSION_PATCH})
 set(CPACK_PACKAGE_VERSION ${AvogadroApp_VERSION})
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "Avogadro2")
-set(CPACK_PACKAGE_VENDOR "http://openchemistry.org/")
+set(CPACK_PACKAGE_VENDOR "https://avogadro.cc/")
 set(CPACK_PACKAGE_DESCRIPTION
   "An advanced molecule editor and visualization application.")
 
@@ -15,6 +15,13 @@ if(APPLE)
   set(CPACK_PACKAGE_ICON
     "${AvogadroApp_SOURCE_DIR}/avogadro/icons/avogadro.icns")
   set(CPACK_BUNDLE_ICON "${CPACK_PACKAGE_ICON}")
+
+  if(${CMAKE_VERSION} VERSION_GREATER "3.19.0") 
+    # add the codesign options to the packageq
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/deploy-osx.cmake.in" "${AvogadroApp_BINARY_DIR}/deploy-osx.cmake" @ONLY)
+    set(CPACK_PRE_BUILD_SCRIPTS "${AvogadroApp_BINARY_DIR}/deploy-osx.cmake")
+  endif()
+
 else()
   set(CPACK_RESOURCE_FILE_LICENSE "${AvogadroApp_SOURCE_DIR}/LICENSE")
 endif()

--- a/cmake/deploy-osx.cmake.in
+++ b/cmake/deploy-osx.cmake.in
@@ -1,0 +1,16 @@
+set(APP_BUNDLE_PATH "${CPACK_TEMPORARY_INSTALL_DIRECTORY}/Avogadro2.app")
+
+if (DEFINED ENV{CODESIGN_IDENTITY})
+    set(COMMAND_ARGS
+        codesign
+        --force
+        --deep
+        --sign "$ENV{CODESIGN_IDENTITY}"
+        ${APP_BUNDLE_PATH}
+    )
+    execute_process(COMMAND ${COMMAND_ARGS} RESULT_VARIABLE EXIT_CODE)
+    if(NOT EXIT_CODE EQUAL 0)
+        message(FATAL_ERROR
+            \"Running ${COMMAND_ARGS} failed with exit code \${EXIT_CODE}.\")
+    endif()
+endif()


### PR DESCRIPTION
Requires CMake 3.19 (available on build systems)

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
