### PR TITLE
Sign all OB plugins for Mac notarization

### DIFF
--- a/cmake/Entitlements.plist
+++ b/cmake/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/cmake/deploy-osx.cmake.in
+++ b/cmake/deploy-osx.cmake.in
@@ -1,10 +1,30 @@
 set(APP_BUNDLE_PATH "${CPACK_TEMPORARY_INSTALL_DIRECTORY}/Avogadro2.app")
 
 if (DEFINED ENV{CODESIGN_IDENTITY})
+    # sign the Open Babel SO files
+    file(GLOB OB_PLUGINS ${APP_BUNDLE_PATH}/Contents/lib/openbabel/*.so)
+
+    foreach(ob_plugin ${OB_PLUGINS})
+        set(OB_ARGS
+            codesign
+            --force
+            --timestamp
+            --sign "$ENV{CODESIGN_IDENTITY}"
+            ${ob_plugin}
+        )
+        execute_process(COMMAND ${OB_ARGS} RESULT_VARIABLE EXIT_CODE)
+        if(NOT EXIT_CODE EQUAL 0)
+            message(FATAL_ERROR
+            \"Running ${OB_ARGS} failed with exit code \${EXIT_CODE}.\")
+        endif()
+    endforeach()
+
     set(COMMAND_ARGS
         codesign
         --force
         --deep
+        --timestamp
+        --options runtime
         --sign "$ENV{CODESIGN_IDENTITY}"
         ${APP_BUNDLE_PATH}
     )

--- a/cmake/deploy-osx.cmake.in
+++ b/cmake/deploy-osx.cmake.in
@@ -25,6 +25,7 @@ if (DEFINED ENV{CODESIGN_IDENTITY})
         --deep
         --timestamp
         --options runtime
+        --entitlements "@CMAKE_SOURCE_DIR@/cmake/Entitlements.plist"
         --sign "$ENV{CODESIGN_IDENTITY}"
         ${APP_BUNDLE_PATH}
     )


### PR DESCRIPTION
Notarization failed because:
-all SO files were unsigned
-timestamps were needed
-executables needed hardened runtime

Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
