### PR TITLE
Improve 'Save As' extension choosing logic

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -1347,10 +1347,11 @@ bool MainWindow::saveFileAs(bool async)
   // Otherwise, get extension from selected filter
   if (extension.isEmpty()) {
     QString filter = saveDialog.selectedNameFilter();
-    if (filter.contains("(*.cjson)", Qt::CaseSensitive))
-      extension = "cjson";
-    else if (filter.contains("(*.cml)", Qt::CaseSensitive))
+    if (filter.contains("(*.cml)", Qt::CaseSensitive))
       extension = "cml";
+    else
+      extension = "cjson";
+
     fileName += "." + extension;
   }
 


### PR DESCRIPTION
I was encountering an issue wherein saving a file without specifying an extension would write it as CJSON format, but add the `.cml` extension. This occurs since the 'Save As' code adds this extension by default, but does not set a writer, so the default one is used.

Additionally, users could expect a file with no explicit extension to be saved with a default extension that matches their currently selected filter, rather than always `.cml` or `.cjson`.

Both of these issues regarding default extensions are handled in this PR.

Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
