### PR TITLE
Parent the instances of plugins, stack mainwindow

### DIFF
--- a/avogadro/avogadro.cpp
+++ b/avogadro/avogadro.cpp
@@ -242,13 +242,12 @@ int main(int argc, char* argv[])
     }
   }
 
-  Avogadro::MainWindow* window =
-    new Avogadro::MainWindow(fileNames, disableSettings);
-  window->setTranslationList(languages, codes);
+  Avogadro::MainWindow window(fileNames, disableSettings);
+  window.setTranslationList(languages, codes);
 #ifdef QTTESTING
-  window->playTest(testFile, testExit);
+  window.playTest(testFile, testExit);
 #endif
-  window->show();
+  window.show();
 
 #ifdef Avogadro_ENABLE_RPC
   // create rpc listener

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -269,7 +269,7 @@ MainWindow::MainWindow(const QStringList& fileNames, bool disableSettings)
     plugin->pluginFactories<ExtensionPluginFactory>();
   qDebug() << "Extension plugins dynamically found…" << extensions.size();
   foreach (ExtensionPluginFactory* factory, extensions) {
-    ExtensionPlugin* extension = factory->createInstance();
+    ExtensionPlugin* extension = factory->createInstance(QCoreApplication::instance());
     if (extension) {
       extension->setParent(this);
       connect(this, &MainWindow::moleculeChanged, extension,
@@ -1071,7 +1071,7 @@ void MainWindow::sceneItemActivated(const QModelIndex& idx)
   }
 }
 
-bool populatePluginModel(ScenePluginModel& model, bool editOnly = false)
+bool populatePluginModel(ScenePluginModel& model, QObject *p, bool editOnly = false)
 {
   if (!model.scenePlugins().empty())
     return false;
@@ -1081,7 +1081,7 @@ bool populatePluginModel(ScenePluginModel& model, bool editOnly = false)
   QList<ScenePluginFactory*> scenePluginFactories =
     plugin->pluginFactories<ScenePluginFactory>();
   foreach (ScenePluginFactory* factory, scenePluginFactories) {
-    ScenePlugin* scenePlugin = factory->createInstance();
+    ScenePlugin* scenePlugin = factory->createInstance(p);
     if (editOnly && scenePlugin) {
       if (scenePlugin->objectName() == "BallStick") {
         model.addItem(scenePlugin);
@@ -1104,7 +1104,7 @@ bool populateTools(T* glWidget)
   QList<ToolPluginFactory*> toolPluginFactories =
     plugin->pluginFactories<ToolPluginFactory>();
   foreach (ToolPluginFactory* factory, toolPluginFactories) {
-    ToolPlugin* tool = factory->createInstance();
+    ToolPlugin* tool = factory->createInstance(QCoreApplication::instance());
     if (tool)
       glWidget->addTool(tool);
   }
@@ -1117,7 +1117,7 @@ void MainWindow::viewActivated(QWidget* widget)
 {
   ActiveObjects::instance().setActiveWidget(widget);
   if (GLWidget* glWidget = qobject_cast<GLWidget*>(widget)) {
-    bool firstRun = populatePluginModel(glWidget->sceneModel());
+    bool firstRun = populatePluginModel(glWidget->sceneModel(), this);
     m_sceneTreeView->setModel(&glWidget->sceneModel());
     populateTools(glWidget);
 
@@ -1153,7 +1153,7 @@ void MainWindow::viewActivated(QWidget* widget)
   }
 #ifdef AVO_USE_VTK
   else if (vtkGLWidget* vtkWidget = qobject_cast<vtkGLWidget*>(widget)) {
-    bool firstRun = populatePluginModel(vtkWidget->sceneModel());
+    bool firstRun = populatePluginModel(vtkWidget->sceneModel(), this);
     m_sceneTreeView->setModel(&vtkWidget->sceneModel());
 
     if (firstRun) {
@@ -1998,7 +1998,7 @@ void MainWindow::buildTools()
   QList<ToolPluginFactory*> toolPluginFactories =
     plugin->pluginFactories<ToolPluginFactory>();
   foreach (ToolPluginFactory* factory, toolPluginFactories) {
-    ToolPlugin* tool = factory->createInstance();
+    ToolPlugin* tool = factory->createInstance(QCoreApplication::instance());
     tool->setParent(this);
     if (tool)
       m_tools << tool;


### PR DESCRIPTION
This fixes a very old issue I never got around to looking into where the dtors for plugins were not being called. Problem 1 is that the MainWindow was allocated on the heap and its destructor wasn't called. Problem 2 was that we had not parented the plugin instances. This appears to work as expected now, one plugin was deleting the molecule.