### PR TITLE
Remove non-translatable HTML from about dialog strings

### DIFF
--- a/avogadro/aboutdialog.cpp
+++ b/avogadro/aboutdialog.cpp
@@ -23,6 +23,13 @@ AboutDialog::AboutDialog(QWidget* parent_)
                "<span style=\" font-size:%1pt; font-weight:600;\">%2</span>"
                "</p></body></html>");
 
+  // Add the labels
+  m_ui->versionLabel->setText(html.arg("20").arg(tr("Version:")));
+  m_ui->libsLabel->setText(html.arg("10").arg(tr("Avogadro Library Version:")));
+  m_ui->qtVersionLabel->setText(html.arg("10").arg(tr("Qt Version:")));
+  m_ui->sslVersionLabel->setText(html.arg("10").arg(tr("SSL Version:")));
+
+  // Add the version numbers
   m_ui->version->setText(html.arg("20").arg(AvogadroApp_VERSION));
   m_ui->libsVersion->setText(html.arg("10").arg(version()));
   m_ui->qtVersion->setText(html.arg("10").arg(qVersion()));

--- a/avogadro/aboutdialog.ui
+++ b/avogadro/aboutdialog.ui
@@ -59,7 +59,7 @@
        <item>
         <widget class="QLabel" name="versionLabel">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:20pt; font-weight:600;&quot;&gt;Version:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Version:</string>
          </property>
          <property name="textFormat">
           <enum>Qt::AutoText</enum>
@@ -72,7 +72,7 @@
        <item>
         <widget class="QLabel" name="version">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:20pt; font-weight:600;&quot;&gt;0.1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>0.1</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -112,16 +112,16 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="libs">
+      <widget class="QLabel" name="libsLabel">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;AvogadroLibs Version:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Avogadro Library Version:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="libsVersion">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;0.1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>0.1</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -161,14 +161,14 @@
      <item>
       <widget class="QLabel" name="qtVersionLabel">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Qt Version:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Qt Version:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="qtVersion">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;0.1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>0.1</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -178,14 +178,14 @@
      <item>
       <widget class="QLabel" name="sslVersionLabel">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;SSL Version:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>SSL Version:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="sslVersion">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;0.1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>0.1</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
