### PR TITLE
Fix bug sending RPC script commands to tools

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -2466,7 +2466,7 @@ void MainWindow::registerToolCommand(QString command, QString description)
   if (!tool)
     return;
 
-  m_toolCommandMap.insert(command, tool);
+  m_toolCommandMap.insert(command, tool->name());
 }
 
 void MainWindow::registerExtensionCommand(QString command, QString description)
@@ -2528,12 +2528,21 @@ bool MainWindow::handleCommand(const QString& command,
     if (glWidget == nullptr)
       return false;
 
-    auto* tool = m_toolCommandMap.value(command);
+    QString toolName = m_toolCommandMap.value(command);
     auto* currentTool = glWidget->activeTool();
-    glWidget->setActiveTool(tool->objectName());
+
+    // find the requested tool
+    auto* tool = currentTool;
+    foreach (ToolPlugin* toolPlugin, glWidget->tools()) {
+      if (toolPlugin->name() == toolName) {
+        glWidget->setActiveTool(toolPlugin);
+        tool = toolPlugin;
+        break;
+      }
+    }
+
     bool result = tool->handleCommand(command, options);
     glWidget->setActiveTool(currentTool);
-
     return result;
   } else if (m_extensionCommandMap.contains(command)) {
     auto* extension = m_extensionCommandMap.value(command);

--- a/avogadro/mainwindow.h
+++ b/avogadro/mainwindow.h
@@ -34,7 +34,7 @@ namespace QtOpenGL {
 class GLWidget;
 }
 
-namespace Io { 
+namespace Io {
 class FileFormat;
 }
 
@@ -432,7 +432,7 @@ private:
   QList<QtGui::ToolPlugin*> m_tools;
   QList<QtGui::ExtensionPlugin*> m_extensions;
   // map from script commands to tools and extensions
-  QMap<QString, QtGui::ToolPlugin*> m_toolCommandMap;
+  QMap<QString, QString> m_toolCommandMap;
   QMap<QString, QtGui::ExtensionPlugin*> m_extensionCommandMap;
   // used for help - provide description for a command
   QMap<QString, QString> m_commandDescriptionsMap;


### PR DESCRIPTION
Save the name of the tool, not the initial pointer That tool pointer doesn't receive the widget, molecule, etc. So we get the up-to-date one from the active glWidget

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
