### PR TITLE
Ensure that title bar correctly displays active molecule file

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -905,7 +905,7 @@ bool MainWindow::openFile(const QString& fileName, Io::FileFormat* reader)
   if (m_fileReadMolecule)
     m_fileReadMolecule->deleteLater();
   m_fileReadMolecule = new Molecule(this);
-  m_fileReadMolecule->setData("fileName", fileName.toLocal8Bit().data());
+  m_fileReadMolecule->setData("fileName", qPrintable(fileName));
   m_threadedReader->moveToThread(m_fileReadThread);
   m_threadedReader->setMolecule(m_fileReadMolecule);
   m_threadedReader->setFileName(fileName);
@@ -941,7 +941,7 @@ void MainWindow::backgroundReaderFinished()
     delete m_fileReadMolecule;
   } else if (m_threadedReader->success()) {
     if (!fileName.isEmpty()) {
-      m_fileReadMolecule->setData("fileName", fileName.toLocal8Bit().data());
+      m_fileReadMolecule->setData("fileName", qPrintable(fileName));
       m_recentFiles.prepend(fileName);
       updateRecentFiles();
     } else {
@@ -1013,8 +1013,7 @@ bool MainWindow::backgroundWriterFinished()
     if (m_threadedWriter->success()) {
       statusBar()->showMessage(
         tr("Saved file %1", "%1 = filename").arg(fileName));
-      m_threadedWriter->molecule()->setData("fileName",
-                                            fileName.toLocal8Bit().data());
+      m_threadedWriter->molecule()->setData("fileName", qPrintable(fileName));
       markMoleculeClean();
       updateWindowTitle();
       success = true;


### PR DESCRIPTION
Noticed while using this software that my active `cjson` file did not seem to appear in the title bar (Ubuntu 22.04, for reference). Tracked this down to the fact that `Variant` will not be instantiated correctly with a `String` `m_type` when a char array is passed and initialized via `setValue`, and the `AVO_UNUSED` path is called instead. To fix this, we can just set the `fileName` attribute as an `std::string` directly via `toStdString` rather than `toLocal8Bit().data()`. 

Before: 
![image](https://github.com/OpenChemistry/avogadroapp/assets/10727824/ab1814ad-c6f6-4c09-af46-748a13880620)

After:
![image](https://github.com/OpenChemistry/avogadroapp/assets/10727824/8b6efd2a-2a17-4cc8-a25d-6f5311fa8a32)




Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
