### PR TITLE
Reduce ambiguity of "Export" toolbar button

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -1971,11 +1971,18 @@ void MainWindow::buildMenu()
   m_fileToolBar->addAction(action);
   connect(action, SIGNAL(triggered()), SLOT(saveFileAs()));
 
-  // Export
-  QStringList exportPath = path;
-  exportPath << tr("&Export");
+  // Export action for menu
+  QStringList exportMenuPath = path;
+  exportMenuPath << tr("&Export");
   action = new QAction(tr("&Molecule…"), this);
-  m_menuBuilder->addAction(exportPath, action, 110);
+  m_menuBuilder->addAction(exportMenuPath, action, 110);
+#ifndef Q_OS_MAC
+  action->setIcon(QIcon::fromTheme("document-export"));
+#endif
+  connect(action, SIGNAL(triggered()), this, SLOT(exportFile()));
+  // Export action for toolbar with more clear name
+  QStringList exportToolbarPath = path;
+  action = new QAction(tr("Export Molecule…"), this);
   m_fileToolBar->addAction(action);
 #ifndef Q_OS_MAC
   action->setIcon(QIcon::fromTheme("document-export"));
@@ -1983,7 +1990,7 @@ void MainWindow::buildMenu()
   connect(action, SIGNAL(triggered()), this, SLOT(exportFile()));
   // Export graphics
   action = new QAction(tr("&Graphics…"), this);
-  m_menuBuilder->addAction(exportPath, action, 100);
+  m_menuBuilder->addAction(exportMenuPath, action, 100);
 #ifndef Q_OS_MAC
   action->setIcon(QIcon::fromTheme("document-export"));
 #endif

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -1972,16 +1972,15 @@ void MainWindow::buildMenu()
   connect(action, SIGNAL(triggered()), SLOT(saveFileAs()));
 
   // Export action for menu
-  QStringList exportMenuPath = path;
-  exportMenuPath << tr("&Export");
+  QStringList exportPath = path;
+  exportPath << tr("&Export");
   action = new QAction(tr("&Molecule…"), this);
-  m_menuBuilder->addAction(exportMenuPath, action, 110);
+  m_menuBuilder->addAction(exportPath, action, 110);
 #ifndef Q_OS_MAC
   action->setIcon(QIcon::fromTheme("document-export"));
 #endif
   connect(action, SIGNAL(triggered()), this, SLOT(exportFile()));
   // Export action for toolbar with more clear name
-  QStringList exportToolbarPath = path;
   action = new QAction(tr("Export Molecule…"), this);
   m_fileToolBar->addAction(action);
 #ifndef Q_OS_MAC
@@ -1990,7 +1989,7 @@ void MainWindow::buildMenu()
   connect(action, SIGNAL(triggered()), this, SLOT(exportFile()));
   // Export graphics
   action = new QAction(tr("&Graphics…"), this);
-  m_menuBuilder->addAction(exportMenuPath, action, 100);
+  m_menuBuilder->addAction(exportPath, action, 100);
 #ifndef Q_OS_MAC
   action->setIcon(QIcon::fromTheme("document-export"));
 #endif


### PR DESCRIPTION
As File>Export has multiple options, what exactly the toolbar button exports is not very clear.

This actually confused me as a user myself once upon a time so figured it was a good thing to try and fix myself.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
