### PR TITLE
Bump version for 1.99 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ include(DetermineVersion)
 
 # Set up our version.
 set(AvogadroApp_VERSION_MAJOR   "1")
-set(AvogadroApp_VERSION_MINOR   "98")
-set(AvogadroApp_VERSION_PATCH   "1")
+set(AvogadroApp_VERSION_MINOR   "99")
+set(AvogadroApp_VERSION_PATCH   "0")
 set(AvogadroApp_VERSION
   "${AvogadroApp_VERSION_MAJOR}.${AvogadroApp_VERSION_MINOR}.${AvogadroApp_VERSION_PATCH}")
 find_package(Git)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,21 @@
-# Security Policy 
+# Security Policy
 
-## Supported Versions 
+## Supported Versions
 
-At the moment, Avogadro2 is in beta release. As such, we can most easily support 
-security updates on the most recent release and current nightly snapshots. 
-We will work with distributions (e.g., Ubuntu, FreeBSD, etc.) to provide security 
+At the moment, Avogadro2 is in beta release. As such, we can most easily support
+security updates on the most recent release and current nightly snapshots.
+We will work with distributions (e.g., Ubuntu, FreeBSD, etc.) to provide security
 patches for widely used long-term-support OS.
 
-| Version | Supported          | 
-| ------- | ------------------ | 
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.99.x  | :white_check_mark: |
 | 1.98.x  | :white_check_mark: |
-| 1.97.x  | :white_check_mark: |
-| < 1.97  | :x:                |
+| < 1.98  | :x:                |
 
-## Reporting a Vulnerability 
+## Reporting a Vulnerability
 
-We currently support private security vulnerability reporting through our 
-[GitHub](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) 
-pages. We will work to verify the security vulnerability within 14 days 
+We currently support private security vulnerability reporting through our
+[GitHub](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+pages. We will work to verify the security vulnerability within 14 days
 and a patch or new release within 30 days of reporting.


### PR DESCRIPTION
Signed-off-by: Geoff Hutchison <geoff.hutchison@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
