### PR TITLE
fix: ‘class Avogadro::QtGui::ToolPlugin’ has no member named ‘setIcon’

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -2192,7 +2192,11 @@ void MainWindow::buildTools()
   foreach (ToolPluginFactory* factory, toolPluginFactories) {
     ToolPlugin* tool = factory->createInstance(QCoreApplication::instance());
     tool->setParent(this);
-    tool->setIcon(darkMode);
+    if (darkMode) {
+    tool->setIcon(true);
+} else {
+    tool->setIcon(false);
+}
     if (tool)
       m_tools << tool;
   }


### PR DESCRIPTION
reason follows
```
[ 96%] Built target i18n
/build/avogadroapp/src/avogadroapp-1.99.0/avogadro/mainwindow.cpp: In member function ‘void Avogadro::MainWindow::buildTools()’:
/build/avogadroapp/src/avogadroapp-1.99.0/avogadro/mainwindow.cpp:2195:11: error: ‘class Avogadro::QtGui::ToolPlugin’ has no member named ‘setIcon’
 2195 |     tool->setIcon(darkMode);
      |           ^~~~~~~
make[2]: *** [avogadro/CMakeFiles/avogadro.dir/build.make:167: avogadro/CMakeFiles/avogadro.dir/mainwindow.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:146: avogadro/CMakeFiles/avogadro.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
