### PR TITLE
Rename View Configuration dock to better reflect its function

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -399,7 +399,7 @@ void MainWindow::setupInterface()
   m_toolDock = new QDockWidget(tr("Tool"), this);
   addDockWidget(Qt::LeftDockWidgetArea, m_toolDock);
 
-  // Our scene/view dock.
+  // Our dock for toggling different display types.
   m_sceneDock = new QDockWidget(tr("Display Types"), this);
   m_sceneTreeView = new QTreeView(m_sceneDock);
   m_sceneTreeView->setIndentation(0);
@@ -408,8 +408,8 @@ void MainWindow::setupInterface()
   m_sceneDock->setWidget(m_sceneTreeView);
   addDockWidget(Qt::LeftDockWidgetArea, m_sceneDock);
 
-  // Our view dock.
-  m_viewDock = new QDockWidget(tr("View Configuration"), this);
+  // Our dock for configuring the display types.
+  m_viewDock = new QDockWidget(tr("Display Type Configuration"), this);
   addDockWidget(Qt::LeftDockWidgetArea, m_viewDock);
 
   // Our molecule dock.
@@ -421,7 +421,7 @@ void MainWindow::setupInterface()
   m_moleculeDock->setWidget(m_moleculeTreeView);
   addDockWidget(Qt::LeftDockWidgetArea, m_moleculeDock);
 
-  // Our molecule dock.
+  // Our layer dock.
   m_layerDock = new QDockWidget(tr("Layers"), this);
   m_layerTreeView = new QTreeView(m_layerDock);
   m_layerTreeView->setIndentation(0);


### PR DESCRIPTION
The name of the View Configuration dock implies that its purpose is to customize the general properties of the view. Perhaps this is once what it did.

However, these days it functions as the place to display extra configuration settings for the display types listed, toggled, and chosen in the Display Types dock.

I believe renaming it to the Display Type Configuration dock better communicates to the user what it does.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
