### PR TITLE
AUTOSAVE FEATURE (#182)

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -1979,6 +1979,42 @@ void MainWindow::buildMenu()
   m_menuBuilder->addAction(path, action, 960);
   m_fileToolBar->addAction(action);
   connect(action, SIGNAL(triggered()), SLOT(saveFileAs()));
+  // Initialize autosave feature
+m_autosaveInterval = 5; // Autosave interval in minutes
+m_autosaveTimer = new QTimer(this);
+connect(m_autosaveTimer, &QTimer::timeout, this, &MainWindow::autosaveDocument);
+m_autosaveTimer->start(m_autosaveInterval * 60000); // Convert minutes to milliseconds
+
+void MainWindow::autosaveDocument()
+{
+    if (!m_molecule || !m_moleculeDirty) {
+        return; // No molecule loaded or no changes made since the last save.
+    }
+
+    QString autosaveDirPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/autosave";
+    QDir autosaveDir(autosaveDirPath);
+    if (!autosaveDir.exists()) {
+        autosaveDir.mkpath(".");
+    }
+
+    // Construct autosave file name
+    QString autosaveFilename;
+    if (m_molecule->hasData("fileName")) {
+        QFileInfo fileInfo(m_molecule->data("fileName").toString().c_str());
+        autosaveFilename = fileInfo.baseName() + "_autosave.cjson";
+    } else {
+        autosaveFilename = "unsaved_autosave.cjson";
+    }
+    QString autosaveFilePath = autosaveDirPath + "/" + autosaveFilename;
+
+    // Use CJSON format for autosaving
+    Io::CjsonFormat writer;
+    if (!writer.writeFile(autosaveFilePath, *m_molecule)) {
+        qWarning() << "Failed to autosave the document to" << autosaveFilePath;
+    } else {
+        qDebug() << "Document autosaved to" << autosaveFilePath;
+    }
+}
 
   // Export action for menu
   QStringList exportPath = path;

--- a/avogadro/mainwindow.h
+++ b/avogadro/mainwindow.h
@@ -69,7 +69,7 @@ public:
 
 public slots:
   void setMolecule(Avogadro::QtGui::Molecule* molecule);
-
+  void autosaveDocument(); //line to declare the autosave slot
   /**
    * Update internal state to reflect that the molecule has been modified.
    */
@@ -391,6 +391,7 @@ private slots:
   void setProjectionPerspective();
 
 private:
+
   QtGui::Molecule* m_molecule;
   QtGui::RWMolecule* m_rwMolecule;
   QtGui::MoleculeModel* m_moleculeModel;
@@ -398,7 +399,8 @@ private:
   QtGui::ScenePlugin* m_activeScenePlugin;
   bool m_queuedFilesStarted;
   QStringList m_queuedFiles;
-
+  QTimer* m_autosaveTimer;  // for the autosave timer
+  int m_autosaveInterval;   // for autosave interval in minutes
   QStringList m_recentFiles;
   QList<QAction*> m_actionRecentFiles;
 


### PR DESCRIPTION
This pull request introduces a new autosave feature to the Avogadro application. The feature aims to enhance the user experience by automatically saving the current molecule document at a specified interval of 5 minutes, reducing the risk of data loss in case of unexpected application closure. The implementation includes setting up an autosave interval with QTimer, determining the autosave directory based on the application data location, and saving the document in the CJSON format. This autosave functionality is careful to activate only if there are unsaved changes, ensuring efficient use of resources and avoiding unnecessary writes. The feature also involves updates to the MainWindow class to incorporate autosave setup and execution logic. This addition is expected to provide a safety net for users, securing their work without requiring manual intervention for frequent saves.

Signed-off-by: vinayakjeet vinayakjeetog@gmail.com