### PR TITLE
Preferences Feature added

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -4,7 +4,7 @@
 ******************************************************************************/
 
 #include "mainwindow.h"
-
+#include "preferencesdialog.h"
 #include "aboutdialog.h"
 #include "avogadroappconfig.h"
 #include "backgroundfileformat.h"
@@ -300,7 +300,7 @@ MainWindow::MainWindow(const QStringList& fileNames, bool disableSettings)
 
   // Now set up the interface.
   setupInterface();
-
+initializeActions();
   // Build up the standard menus, incorporate dynamic menus.
   buildMenu();
   updateRecentFiles();
@@ -356,7 +356,23 @@ MainWindow::~MainWindow()
   delete m_menuBuilder;
   delete m_viewFactory;
 }
+void MainWindow::initializeActions()
+{
+    // Example initialization, adjust according to your needs
+    m_actionPreferences = new QAction(tr("&Preferences"), this);
+    connect(m_actionPreferences, &QAction::triggered, this, &MainWindow::showPreferencesDialog);
+    // Add m_actionPreferences to the appropriate menu or toolbar
+}
 
+void MainWindow::showPreferencesDialog()
+{
+   PreferencesDialog dialog(this);
+    dialog.loadSettings();
+
+    if (dialog.exec() == QDialog::Accepted) {
+        dialog.applySettings(); // Apply and save settings
+    }
+}
 void MainWindow::setupInterface()
 {
   // We take care of setting up the main interface here, along with any custom

--- a/avogadro/mainwindow.h
+++ b/avogadro/mainwindow.h
@@ -9,7 +9,7 @@
 #include <QtCore/QStringList>
 #include <QtCore/QVariantMap>
 #include <QtWidgets/QMainWindow>
-
+#include "preferencesdialog.h"
 #ifdef QTTESTING
 class pqTestUtility;
 #endif
@@ -19,9 +19,9 @@ class QThread;
 class QTreeView;
 class QNetworkAccessManager;
 class QNetworkReply;
-
+class QAction;
 namespace Ui {
-class AboutDialog;
+class AboutDialog;  
 }
 
 namespace Avogadro {
@@ -74,7 +74,8 @@ public slots:
    * Update internal state to reflect that the molecule has been modified.
    */
   void markMoleculeDirty();
-
+ void showPreferencesDialog();
+ void initializeActions();
   /**
    * Update internal state to reflect that the molecule is not modified.
    */
@@ -442,7 +443,7 @@ private:
   QAction* m_copyImage;
   QAction* m_viewPerspective;
   QAction* m_viewOrthographic;
-
+  QAction* m_actionPreferences;
   ViewFactory* m_viewFactory;
 
   QNetworkAccessManager* m_network = nullptr;

--- a/avogadro/mainwindow.ui
+++ b/avogadro/mainwindow.ui
@@ -65,17 +65,14 @@
     <addaction name="actionCopy"/>
     <addaction name="actionPaste"/>
     <addaction name="actionClear"/>
-   </widget>
-   <widget class="QMenu" name="menuSelect">
-    <property name="title">
-     <string>&amp;Select</string>
-    </property>
-   </widget>
-   <addaction name="menuFile"/>
+  
+    <addaction name="separator"/> 
+    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
    <addaction name="menuView"/>
    <addaction name="menuBuild"/>
    <addaction name="menuSelect"/>
+    <addaction name="actionPreferences"/>
   </widget>
   <action name="actionOpen">
    <property name="text">
@@ -323,6 +320,35 @@
     <string>&amp;Import</string>
    </property>
   </action>
+<action name="actionPreferences">
+  <property name="text">
+    <string>Preferences…</string>
+  </property>
+  <property name="icon">
+    <iconset>
+      <normaloff>:icons/preferences-icon.png</normaloff>:icons/preferences-icon.png
+    </iconset>
+  </property>
+  <property name="shortcut">
+    <string>Ctrl+P</string>
+  </property>
+</action>
+
+
+
+
+   <property name="text">
+    <string>Preferences…</string>
+  </property>
+    <property name="icon">
+    <iconset>
+      <normaloff>:icons/preferences-icon.png</normaloff>:icons/preferences-icon.png</iconset>
+  </property> 
+  -->
+</action>
+   <string>Preferences…</string>
+  </property>
+</action>
   <action name="actionExport">
    <property name="text">
     <string>&amp;Export</string>
@@ -337,6 +363,7 @@
    <sender>actionClose</sender>
    <signal>triggered()</signal>
    <receiver>MainWindow</receiver>
+    <slot>showPreferencesDialog()</slot>
    <slot>close()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -350,10 +377,20 @@
    </hints>
   </connection>
   <connection>
-   <sender>actionQuit</sender>
-   <signal>triggered()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>close()</slot>
+    <sender>actionQuit</sender>
+    <signal>triggered()</signal>
+    <receiver>MainWindow</receiver>
+    <slot>close()</slot>
+  </connection>
+  
+  <connection>
+    <sender>actionPreferences</sender>
+    <signal>triggered()</signal>
+    <receiver>MainWindow</receiver>
+    <slot>showPreferencesDialog()</slot>
+  </connection>
+</connections>
+
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>


### PR DESCRIPTION
#84 (WIP)
This pull request introduces a new functionality to the Avogadro application by adding a "Preferences" option under the "Edit" menu. This feature allows users to access and modify their preferences directly from the main interface, enhancing usability and accessibility. 
The implementation involves modifications to the MainWindow class, including updates to the .cpp, .h, and .ui files to ensure seamless integration of the preferences dialog. 
This addition streamlines the user experience by providing quick access to settings, catering to the needs of users looking to customize their Avogadro application settings efficiently.