### PR TITLE
Qt6: restore QRegExp port, remove Qt6Core5Compat dependency

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -35,7 +35,7 @@ jobs:
             os: ubuntu-20.04,
             cc: "gcc", cxx: "g++",
             build_type: "Release",
-            cmake_flags: "-G Ninja -DINSTALL_BUNDLE_FILES=ON -DCMAKE_BUILD_TYPE=Release",
+            cmake_flags: "-G Ninja -DBUILD_MOLEQUEUE=OFF -DINSTALL_BUNDLE_FILES=ON -DCMAKE_BUILD_TYPE=Release",
             cpack: "",
           }
         - {
@@ -43,7 +43,7 @@ jobs:
             os: macos-latest,
             cc: "clang", cxx: "clang++",
             build_type: "Release",
-            cmake_flags: "-G Ninja",
+            cmake_flags: "-G Ninja -DBUILD_MOLEQUEUE=OFF",
             cpack_flags: "-G DragNDrop",
           }
         - {
@@ -51,7 +51,7 @@ jobs:
             os: windows-latest,
             cc: "cl", cxx: "cl",
             build_type: "Release",
-            cmake_flags: "",
+            cmake_flags: "-DBUILD_MOLEQUEUE=OFF",
             build_flags: "-j 2",
             cpack_flags: "-G NSIS",
             ssl_env: "D:\\a\\avogadroapp\\Qt\\Tools\\OpenSSLv3\\Win_x64",

--- a/avogadro/CMakeLists.txt
+++ b/avogadro/CMakeLists.txt
@@ -25,12 +25,16 @@ if(QT_VERSION EQUAL 6)
       Concurrent
       Widgets
       Network
-      Core5Compat
       OpenGL
       OpenGLWidgets
     REQUIRED)
 else()
-  find_package(Qt5 COMPONENTS Concurrent Widgets Network REQUIRED)
+  find_package(Qt5
+    COMPONENTS
+      Concurrent
+      Widgets
+      Network
+    REQUIRED)
 endif()
 
 configure_file(avogadroappconfig.h.in avogadroappconfig.h)
@@ -212,7 +216,7 @@ if(ENABLE_TESTING)
   target_link_libraries(avogadro QtTesting)
 endif()
 if(QT_VERSION EQUAL 6)
-  target_link_libraries(avogadro Qt6::Core5Compat Qt6::OpenGL Qt6::OpenGLWidgets)
+  target_link_libraries(avogadro Qt6::OpenGL Qt6::OpenGLWidgets)
 endif()
 
 if(USE_3DCONNEXION AND (WIN32 OR APPLE))

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -2359,10 +2359,12 @@ void MainWindow::registerMoleQueue()
   StringList exts = ffm.fileExtensions(FileFormat::Read | FileFormat::File);
 
   // Create patterns list
-  QList<QRegExp> patterns;
+  QList<QRegularExpression> patterns;
   for (auto it = exts.begin(), itEnd = exts.end(); it != itEnd; ++it) {
-    patterns << QRegExp(extensionToWildCard(QString::fromStdString(*it)),
-                        Qt::CaseInsensitive, QRegExp::Wildcard);
+    patterns << QRegularExpression(
+      QRegularExpression::wildcardToRegularExpression(
+        extensionToWildCard(QString::fromStdString(*it))),
+      QRegularExpression::CaseInsensitive);
   }
 
   // Register the executable:


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
