### PR TITLE
Use Qt/KDE runtime 6.8 for Flatpak test builds

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -84,7 +84,7 @@ jobs:
       run: mv openchemistry/avogadroapp/flatpak/org.openchemistry.Avogadro2.yaml ./
 
     - name: Build with flatpak-builder
-      run: flatpak run org.flatpak.Builder --force-clean --user --install-deps-from=flathub --arch=x86_64 --default-branch=test --repo=repo builddir org.openchemistry.Avogadro2.yaml
+      run: dbus-run-session flatpak run org.flatpak.Builder --force-clean --user --install-deps-from=flathub --arch=x86_64 --default-branch=test --repo=repo builddir org.openchemistry.Avogadro2.yaml
 
     - name: Create bundle
       run: flatpak build-bundle repo Avogadro2.flatpak org.openchemistry.Avogadro2 test

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -14,6 +14,9 @@ jobs:
     - name: Configure flatpak
       run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
+    - name: Install flatpak-builder
+      run: flatpak --user install --or-update --noninteractive flathub org.flatpak.Builder
+
     - name: Configure git
       run: git config --global protocol.file.allow always
       # Have to do this because for a while git's handling of submodules was broken
@@ -81,7 +84,7 @@ jobs:
       run: mv openchemistry/avogadroapp/flatpak/org.openchemistry.Avogadro2.yaml ./
 
     - name: Build with flatpak-builder
-      run: flatpak-builder --force-clean --user --install-deps-from=flathub --arch=x86_64 --default-branch=test --repo=repo builddir org.openchemistry.Avogadro2.yaml
+      run: flatpak run org.flatpak.Builder --force-clean --user --install-deps-from=flathub --arch=x86_64 --default-branch=test --repo=repo builddir org.openchemistry.Avogadro2.yaml
 
     - name: Create bundle
       run: flatpak build-bundle repo Avogadro2.flatpak org.openchemistry.Avogadro2 test

--- a/flatpak/org.openchemistry.Avogadro2.yaml
+++ b/flatpak/org.openchemistry.Avogadro2.yaml
@@ -23,6 +23,10 @@ modules:
   - name: rapidjson
     buildsystem: cmake-ninja
     builddir: true
+    config-opts:
+      - -DRAPIDJSON_BUILD_DOC=OFF
+      - -DRAPIDJSON_BUILD_EXAMPLES=OFF
+      - -DRAPIDJSON_BUILD_TESTS=OFF
     sources:
       - type: git
         url: https://github.com/Tencent/rapidjson.git
@@ -37,7 +41,7 @@ modules:
     no-make-install: true  # Superbuild doesn't have `install` command defined
     config-opts:
       # Match GitHub builds as much as possible, which generally means using defaults
-      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_BUILD_TYPE=Debug
       - -DUSE_VTK=ON
       - -DBUILD_GPL_PLUGINS=ON
       - -DBUILD_MOLEQUEUE=OFF

--- a/flatpak/org.openchemistry.Avogadro2.yaml
+++ b/flatpak/org.openchemistry.Avogadro2.yaml
@@ -1,7 +1,7 @@
 app-id: org.openchemistry.Avogadro2
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: "6.7"
+runtime-version: "6.8"
 command: avogadro2
 appdata-license: BSD-3-Clause AND GPL-2.0-only
 finish-args:
@@ -11,7 +11,6 @@ finish-args:
   - --device=dri  # OpenGL rendering
   - --share=network  # For plugin downloads
 cleanup:
-  - /include
   - /lib/cmake
   - '*.la'
   - '*.a'
@@ -107,5 +106,9 @@ modules:
 
     post-install:
       # Manually copy contents of prefix dir over into main build dir
-      # -a option is recursive should preserve permissions and symlinks
-      - cp -a prefix/* -t ${FLATPAK_DEST}/
+      # -a option is recursive, should preserve permissions and symlinks
+      - cp -a prefix/bin -t ${FLATPAK_DEST}/
+      - cp -a prefix/lib -t ${FLATPAK_DEST}/
+      - cp -a prefix/lib64/* -t ${FLATPAK_DEST}/lib/  # Merge with lib
+      - ln -rs ${FLATPAK_DEST}/lib ${FLATPAK_DEST}/lib64  # Add a symlink so plugins get found
+      - cp -a prefix/share -t ${FLATPAK_DEST}/


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
