### PR TITLE
Read UTF-16 files through Qt decoding to a temporary file

### DIFF
--- a/avogadro/backgroundfileformat.cpp
+++ b/avogadro/backgroundfileformat.cpp
@@ -7,11 +7,18 @@
 
 #include <avogadro/io/fileformat.h>
 
+#include <QtCore/QFile>
+#include <QtCore/QTemporaryDir>
+#include <QtCore/QTextStream>
+
 namespace Avogadro {
 
 BackgroundFileFormat::BackgroundFileFormat(Io::FileFormat* format,
                                            QObject* aparent)
-  : QObject(aparent), m_format(format), m_molecule(nullptr), m_success(false)
+  : QObject(aparent)
+  , m_format(format)
+  , m_molecule(nullptr)
+  , m_success(false)
 {
 }
 
@@ -35,8 +42,54 @@ void BackgroundFileFormat::read()
     m_error = tr("No file name set in BackgroundFileFormat!");
 
   if (m_error.isEmpty()) {
-    m_success = m_format->readFile(m_fileName.toLocal8Bit().data(),
-                                   *m_molecule);
+    // sometimes we hit UTF-16 files, so we need to convert them to UTF-8
+    // first check whether the file is UTF-16
+    QFile file(m_fileName);
+    QTextStream in(&file);
+    QString text;
+    bool isUTF16 = false;
+    if (file.open(QIODevice::ReadOnly)) {
+      QByteArray data = file.read(2);
+      // look for a byte-order mark
+      if ((data.size() == 2 && data[0] == '\xff' && data[1] == '\xfe') ||
+          (data.size() == 2 && data[0] == '\xfe' && data[1] == '\xff')) {
+        // UTF-16, read the file and let QString handle decoding
+        isUTF16 = true;
+        file.close();
+        file.open(QIODevice::ReadOnly | QIODevice::Text);
+        in.setCodec("UTF-16");
+        text = in.readAll();
+        file.close();
+      }
+    }
+
+    if (!isUTF16)
+      m_success =
+        m_format->readFile(m_fileName.toLocal8Bit().data(), *m_molecule);
+    else {
+      // write it to a temporary file and we'll read it back in
+      // some formats (like the generic output) need a file
+      // not just a string bugger
+
+      // first, we need the *name* of the file, not the full path
+      // because we're going to save a copy in a temp directory
+      QTemporaryDir tempDir;
+      QString tempFileName = tempDir.filePath(QFileInfo(m_fileName).fileName());
+      QFile tempFile(tempFileName);
+      if (tempFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QTextStream out(&tempFile);
+        // set it to UTF-8
+        out.setCodec("UTF-8");
+        out << text;
+        out.flush();
+        tempFile.close();
+        m_success =
+          m_format->readFile(tempFileName.toLocal8Bit().data(), *m_molecule);
+        tempFile.remove();
+      } else // try just reading the string
+        m_success =
+          m_format->readString(text.toLocal8Bit().data(), *m_molecule);
+    }
 
     if (!m_success)
       m_error = QString::fromStdString(m_format->error());
@@ -60,8 +113,8 @@ void BackgroundFileFormat::write()
     m_error = tr("No file name set in BackgroundFileFormat!");
 
   if (m_error.isEmpty()) {
-    m_success = m_format->writeFile(m_fileName.toLocal8Bit().data(),
-                                    *m_molecule);
+    m_success =
+      m_format->writeFile(m_fileName.toLocal8Bit().data(), *m_molecule);
 
     if (!m_success)
       m_error = QString::fromStdString(m_format->error());

--- a/avogadro/backgroundfileformat.cpp
+++ b/avogadro/backgroundfileformat.cpp
@@ -42,70 +42,57 @@ void BackgroundFileFormat::read()
     m_error = tr("No file name set in BackgroundFileFormat!");
 
   if (m_error.isEmpty()) {
-    #if QT_VERSION >= 0x060000
-      QFile file(m_fileName);
-      if (file.open(QFile::ReadOnly | QIODevice::Text)) {
-        QTextStream in(&file);
-        QString text;
+    // sometimes we hit UTF-16 files, so we need to convert them to UTF-8
+    // first check whether the file is UTF-16
+    QFile file(m_fileName);
+    QTextStream in(&file);
+    QString text;
+    bool isUTF16 = false;
+    if (file.open(QIODevice::ReadOnly)) {
+      QByteArray data = file.read(2);
+      // look for a byte-order mark
+      if ((data.size() == 2 && data[0] == '\xff' && data[1] == '\xfe') ||
+          (data.size() == 2 && data[0] == '\xfe' && data[1] == '\xff')) {
+        // UTF-16, read the file and let QString handle decoding
+        isUTF16 = true;
+        file.close();
+        file.open(QIODevice::ReadOnly | QIODevice::Text);
+        in.setCodec("UTF-16");
         text = in.readAll();
         file.close();
+      }
+    }
+
+    if (!isUTF16)
+      m_success =
+        m_format->readFile(m_fileName.toLocal8Bit().data(), *m_molecule);
+    else {
+      // write it to a temporary file and we'll read it back in
+      // some formats (like the generic output) need a file
+      // not just a string bugger
+
+      // first, we need the *name* of the file, not the full path
+      // because we're going to save a copy in a temp directory
+      QTemporaryDir tempDir;
+      QString tempFileName = tempDir.filePath(QFileInfo(m_fileName).fileName());
+      QFile tempFile(tempFileName);
+      if (tempFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QTextStream out(&tempFile);
+        // set it to UTF-8
+        out.setCodec("UTF-8");
+        out << text;
+        out.flush();
+        tempFile.close();
+        m_success =
+          m_format->readFile(tempFileName.toLocal8Bit().data(), *m_molecule);
+        tempFile.remove();
+      } else // try just reading the string
         m_success =
           m_format->readString(text.toLocal8Bit().data(), *m_molecule);
-      }
+    }
 
-    #else
-      // sometimes we hit UTF-16 files, so we need to convert them to UTF-8
-      // first check whether the file is UTF-16
-      QFile file(m_fileName);
-      QTextStream in(&file);
-      QString text;
-      bool isUTF16 = false;
-      if (file.open(QIODevice::ReadOnly)) {
-        QByteArray data = file.read(2);
-        // look for a byte-order mark
-        if ((data.size() == 2 && data[0] == '\xff' && data[1] == '\xfe') ||
-            (data.size() == 2 && data[0] == '\xfe' && data[1] == '\xff')) {
-          // UTF-16, read the file and let QString handle decoding
-          isUTF16 = true;
-          file.close();
-          file.open(QIODevice::ReadOnly | QIODevice::Text);
-          in.setCodec("UTF-16");
-          text = in.readAll();
-          file.close();
-        }
-      }
-
-      if (!isUTF16)
-        m_success =
-          m_format->readFile(m_fileName.toLocal8Bit().data(), *m_molecule);
-      else {
-        // write it to a temporary file and we'll read it back in
-        // some formats (like the generic output) need a file
-        // not just a string bugger
-
-        // first, we need the *name* of the file, not the full path
-        // because we're going to save a copy in a temp directory
-        QTemporaryDir tempDir;
-        QString tempFileName = tempDir.filePath(QFileInfo(m_fileName).fileName());
-        QFile tempFile(tempFileName);
-        if (tempFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-          QTextStream out(&tempFile);
-          // set it to UTF-8
-          out.setCodec("UTF-8");
-          out << text;
-          out.flush();
-          tempFile.close();
-          m_success =
-            m_format->readFile(tempFileName.toLocal8Bit().data(), *m_molecule);
-          tempFile.remove();
-        } else // try just reading the string
-          m_success =
-            m_format->readString(text.toLocal8Bit().data(), *m_molecule);
-      }
-
-      if (!m_success)
-        m_error = QString::fromStdString(m_format->error());
-    #endif
+    if (!m_success)
+      m_error = QString::fromStdString(m_format->error());
   }
 
   emit finished();

--- a/avogadro/backgroundfileformat.cpp
+++ b/avogadro/backgroundfileformat.cpp
@@ -57,7 +57,9 @@ void BackgroundFileFormat::read()
         isUTF16 = true;
         file.close();
         file.open(QIODevice::ReadOnly | QIODevice::Text);
+#if QT_VERSION < 0x060000
         in.setCodec("UTF-16");
+#endif
         text = in.readAll();
         file.close();
       }
@@ -79,7 +81,11 @@ void BackgroundFileFormat::read()
       if (tempFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QTextStream out(&tempFile);
         // set it to UTF-8
+#if QT_VERSION > 0x060000
+        out.setEncoding(QStringConverter::Utf8);
+#else
         out.setCodec("UTF-8");
+#endif
         out << text;
         out.flush();
         tempFile.close();


### PR DESCRIPTION
Fixes https://github.com/OpenChemistry/avogadrolibs/issues/1689

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
