### PR TITLE
When multiple files are dropped, make sure to queue them for reading

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -566,9 +566,14 @@ void MainWindow::dropEvent(QDropEvent* event)
         if (extension == "py")
           addScript(fileName);
         else
-          openFile(fileName);
+          // add these to m_queuedFiles
+          // so we can read them later
+          m_queuedFiles.append(fileName);
       }
     }
+    if (!m_queuedFiles.empty())
+      readQueuedFiles();
+
     event->acceptProposedAction();
   } else
     event->ignore();
@@ -953,6 +958,7 @@ bool MainWindow::openFile(const QString& fileName, Io::FileFormat* reader)
   // Prepare the background thread to read in the selected file.
   if (!m_fileReadThread)
     m_fileReadThread = new QThread(this);
+
   if (m_threadedReader)
     m_threadedReader->deleteLater();
   m_threadedReader = new BackgroundFileFormat(reader);


### PR DESCRIPTION
Previously, openFile() was called directly which would crash because the background thread would get killed before finishing

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
