### PR TITLE
ci: rename path to avogenerators

### DIFF
--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -46,11 +46,11 @@ jobs:
         repository: openchemistry/avogadro-i18n
         path: openchemistry/avogadro-i18n
     
-    - name: Checkout avogadrogenerators
+    - name: Checkout avogenerators
       uses: actions/checkout@v5
       with:
         repository: openchemistry/avogenerators
-        path: openchemistry/avogadrogenerators
+        path: openchemistry/avogenerators
 
     - name: Checkout crystals
       uses: actions/checkout@v5

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -96,11 +96,11 @@ jobs:
         repository: openchemistry/avogadro-i18n
         path: openchemistry/avogadro-i18n
 
-    - name: Checkout avogadrogenerators
+    - name: Checkout avogenerators
       uses: actions/checkout@v5
       with:
         repository: openchemistry/avogenerators
-        path: openchemistry/avogadrogenerators
+        path: openchemistry/avogenerators
 
     - name: Checkout crystals
       uses: actions/checkout@v5


### PR DESCRIPTION
OpenChemistry/avogadrolibs#2197

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
