### PR TITLE
Fix some typos in the NSIS script

### DIFF
--- a/cmake/avogadro2.nsi.in
+++ b/cmake/avogadro2.nsi.in
@@ -28,23 +28,6 @@ RequestExecutionLevel admin
 !insertmacro MUI_UNPAGE_CONFIRM
 !insertmacro MUI_UNPAGE_INSTFILES
 
-;--------------------------------
-; Upgrade logic
-;--------------------------------
-Function .onInit
-  ; Check if Avogadro 2 already installed
-  ReadRegStr $OLD_INSTDIR HKLM "Software\Avogadro2" "Install_Dir"
-  ${If} $OLD_INSTDIR != ""
-    MessageBox MB_YESNO|MB_ICONQUESTION "An existing version of Avogadro 2 was found at:$\n$OLD_INSTDIR$\n$\nDo you want to upgrade (overwrite) it?" IDYES do_upgrade IDNO no_upgrade
-    do_upgrade:
-      StrCpy $INSTDIR $OLD_INSTDIR
-      Goto done
-    no_upgrade:
-      ; continue to let user pick new directory
-    done:
-  ${EndIf}
-FunctionEnd
-
 ; Language Selection
 !insertmacro MUI_LANGUAGE "English"
 !insertmacro MUI_LANGUAGE "Arabic"
@@ -82,7 +65,6 @@ FunctionEnd
 !insertmacro MUI_LANGUAGE "Thai"
 !insertmacro MUI_LANGUAGE "TradChinese"
 !insertmacro MUI_LANGUAGE "Turkish"
-!insertmacro MUI_LANGUAGE "Ukranian"
 !insertmacro MUI_LANGUAGE "Vietnamese"
 
 


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
