### PR TITLE
avogadroapp: Fix File → Close behavior (addresses OpenChemistry/avoga…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+cmake-build-*/

--- a/avogadro/mainwindow.h
+++ b/avogadro/mainwindow.h
@@ -297,6 +297,8 @@ private slots:
 
   void checkUpdate();
 
+  void closeActiveMolecule();
+
   void finishUpdateRequest(QNetworkReply*);
 
   void registerToolCommand(QString command, QString description);


### PR DESCRIPTION
This PR fixes the behavior of File → Close.

- The issue was originally raised in avogadrolibs, but the problem was located in avogadroapp.
- File → Close now closes only the active molecule instead of quitting the entire app.
- Menu entry renamed to 'Close Active Molecule' for clarity.
- Main window close (Cmd–Q / red X) continues to quit the app as intended.

Fixes OpenChemistry/avogadrolibs#2002