### PR TITLE
Fix zoom with orthographic projection - make sure to resetCamera

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -685,10 +685,14 @@ void MainWindow::newMolecule()
 template<class T, class M>
 void setWidgetMolecule(T* glWidget, M* mol)
 {
+  // reset the camera when the previous molecule was empty
+  M* previousMol = glWidget->molecule();
+  bool needReset = (previousMol == nullptr || previousMol->atomCount() == 0);
   glWidget->setMolecule(mol);
   glWidget->updateScene();
-  if (mol->atomCount() == 0)
+  if (needReset) {
     glWidget->resetCamera();
+  }
 }
 
 void setDefaultViews(MultiViewWidget* viewWidget)


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera reset behavior when switching between molecules. The camera now correctly resets when transitioning from an empty molecule state to a new one, providing a more seamless viewing experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->