### PR TITLE
Allow export to the same filename (and format) from the warning

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -1738,7 +1738,8 @@ bool MainWindow::saveFile(bool async)
     else if (box.clickedButton() == cancelButton)
       return false;
     else if (box.clickedButton() == exportButton)
-      return exportFile(async);
+      return exportFile(QString ::fromStdString(fileName),
+                        async); // save in current format
   }
 
   // Otherwise, prompt for a new valid format.


### PR DESCRIPTION
When "save" from an XYZ file, show the warning, but "export" exports to that name without needing a new dialog

Fix #713

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
