### PR TITLE
Key events were not sent to tools because glWidget lacked focus

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -775,6 +775,7 @@ void MainWindow::setMolecule(Molecule* mol)
   QWidget* w = m_multiViewWidget->activeWidget();
   if (auto* glWidget = qobject_cast<QtOpenGL::GLWidget*>(w)) {
     setWidgetMolecule(glWidget, mol);
+    glWidget->setFocus();
   }
 #ifdef AVO_USE_VTK
   else if (auto* vtkWidget = qobject_cast<vtkGLWidget*>(w)) {
@@ -1940,6 +1941,7 @@ void MainWindow::setActiveTool(QString toolName)
         m_toolDock->setWindowTitle(toolPlugin->activateAction()->text());
       }
     }
+    glWidget->setFocus();
   }
 
   if (!toolName.isEmpty()) {


### PR DESCRIPTION
The default focus should now be the widget (and thus tools)

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
