### PR TITLE
Add support for removing old plugins on first launch

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -669,12 +669,9 @@ void MainWindow::dropEvent(QDropEvent* event)
         QFileInfo info(fileName);
         QString extension = info.completeSuffix(); // e.g. .tar.gz or .pdb.gz
 
-        if (extension == "py")
-          addScript(fileName);
-        else
-          // add these to m_queuedFiles
-          // so we can read them later
-          m_queuedFiles.append(fileName);
+        // add these to m_queuedFiles
+        // so we can read them later
+        m_queuedFiles.append(fileName);
       }
     }
     if (!m_queuedFiles.empty())
@@ -991,87 +988,6 @@ void MainWindow::importFile()
       this, tr("Cannot open file"),
       tr("Can't open supplied file %1").arg(reply.second));
   }
-}
-
-bool MainWindow::addScript(const QString& filePath)
-{
-  if (filePath.isEmpty()) {
-    return false;
-  }
-
-  // Ask the user what type of script this is
-  // TODO: add some sort of warning?
-  QStringList types;
-  types << tr("Commands") << tr("Input Generators") << tr("File Formats")
-        << tr("Charges", "atomic electrostatics")
-        << tr("Force Fields", "potential energy calculators");
-
-  bool ok;
-  QString item =
-    QInputDialog::getItem(this, tr("Install Plugin Script"), tr("Script Type:"),
-                          types, 0, false, &ok);
-
-  if (!ok || item.isEmpty())
-    return false;
-
-  QString typePath;
-
-  int index = types.indexOf(item);
-
-  // don't translate these
-  switch (index) {
-    case 0: // commands
-      typePath = "commands";
-      break;
-    case 1:
-      typePath = "inputGenerators";
-      break;
-    case 2:
-      typePath = "formatScripts";
-      break;
-    case 3:
-      typePath = "charges";
-      break;
-    case 4:
-      typePath = "energy";
-      break;
-    default:
-      typePath = "other";
-  }
-
-  QStringList stdPaths =
-    QStandardPaths::standardLocations(QStandardPaths::AppLocalDataLocation);
-
-  QFileInfo info(filePath);
-
-  // check if the directory structure exists first
-  // and if not, create what we need
-  int i = 0;
-  bool createDir = true;
-  for (i = 0; i < stdPaths.size(); ++i) {
-    if (QDir(stdPaths[i] + '/' + typePath).exists()) {
-      createDir = false;
-      break;
-    }
-  }
-  if (createDir) {
-    // find a path we can create (e.g., first path might be admin-only)
-    for (i = 0; i < stdPaths.size(); ++i) {
-      if (QDir().mkpath(stdPaths[i] + '/' + typePath))
-        break;
-    }
-  }
-
-  QString destinationPath(stdPaths[i] + '/' + typePath + '/' + info.fileName());
-#ifndef NDEBUG
-  qDebug() << " copying " << filePath << " to " << destinationPath;
-#endif
-  QFile::remove(destinationPath); // silently fail if there's nothing to remove
-  QFile::copy(filePath, destinationPath);
-
-  // TODO: Ask that type of plugin script to reload?
-
-  return true;
 }
 
 bool MainWindow::openFile(const QString& fileName, Io::FileFormat* reader)

--- a/avogadro/mainwindow.h
+++ b/avogadro/mainwindow.h
@@ -119,11 +119,6 @@ public slots:
    */
   std::string exportString(const std::string& format);
 
-  /**
-   * Move @a fileName as a plugin script (i.e. put it in the correct dir)
-   */
-  bool addScript(const QString& fileName);
-
 #ifdef QTTESTING
   void playTest(const QString& fileName, bool exit = true);
 #endif


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* First-run setup now automatically detects legacy files from previous installations and prompts users to remove them, showing disk space that can be freed
* Improved plugin initialization that automatically detects and configures bundled plugins during startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->