### PR TITLE
Reset the background color to transparent black before export

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -1813,7 +1813,13 @@ QImage MainWindow::renderToImage(const QSize& size)
     scene = &viewWidget->renderer().scene();
   }
   Vector4ub cColor = scene->backgroundColor();
+  unsigned char red = cColor[0];
+  unsigned char green = cColor[1];
+  unsigned char blue = cColor[2];
   unsigned char alpha = cColor[3];
+  cColor[0] = 0;
+  cColor[1] = 0;
+  cColor[2] = 0;
   cColor[3] = 0; // 100% transparent for export
   scene->setBackgroundColor(cColor);
 
@@ -1829,6 +1835,9 @@ QImage MainWindow::renderToImage(const QSize& size)
 
   // set the GL widget back to the right background color (i.e., not 100%
   // transparent)
+  cColor[0] = red;
+  cColor[1] = green;
+  cColor[2] = blue;
   cColor[3] = alpha; // previous color
   scene->setBackgroundColor(cColor);
   glWidget->repaint();


### PR DESCRIPTION
Otherwise we "bake in" the background color into the alpha channel

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed background color handling in image exports to ensure original colors are accurately preserved when rendering scenes to image files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->