### PR TITLE
Fix NSIS shortcuts for all-user installs

### DIFF
--- a/cmake/avogadro2.nsi.in
+++ b/cmake/avogadro2.nsi.in
@@ -103,6 +103,9 @@ FunctionEnd
 
 ; Installer Section
 Section "Install"
+    ; Use the all-users shell folders for Start Menu and Desktop shortcuts.
+    SetShellVarContext all
+
     SetOutPath "$INSTDIR"
 
     ; Copy bin directory
@@ -189,6 +192,9 @@ SectionEnd
 
 ; Uninstaller Section
 Section "Uninstall"
+    ; Remove shortcuts from the same all-users shell folders used by install.
+    SetShellVarContext all
+
     ; Unregister file associations
     Push ".xyz"
     Call un.UnregisterFileAssociation


### PR DESCRIPTION
## Description

Fixes #744. The NSIS installer already requests admin elevation and writes the install/uninstall metadata under HKLM, but it creates Start Menu and Desktop shortcuts without switching NSIS shell variables to the all-users context.

This adds `SetShellVarContext all` before shortcut creation and before uninstall removes those shortcuts, so `$SMPROGRAMS` and `$DESKTOP` resolve to the all-users shell folders consistently.

## Duplicate check

- Checked issue #744 comments before implementation; there was maintainer discussion but no competing patch.
- `gh pr list --repo OpenChemistry/avogadroapp --state all --search "744 NSIS installer shortcuts only created current"` returned no PRs.
- `gh pr list --repo OpenChemistry/avogadroapp --state all --search "NSIS installer shortcuts current user all users SetShellVarContext"` returned no PRs.

## Testing

```bash
git diff --check
NSISDIR="$HOMEBREW_PREFIX/opt/makensis/share/nsis" makensis -VERSION
NSISDIR="$HOMEBREW_PREFIX/opt/makensis/share/nsis" makensis avogadro2.nsi
```

`makensis` was installed with Homebrew (`makensis` 3.12, 9.5 MB). The compile check used a temporary staged copy of `cmake/avogadro2.nsi.in` with `@AvogadroApp_VERSION@` replaced by `1.0.0`, the repo icon copied into `share/icons/avogadro.ico`, and tiny placeholder `bin/lib/share` payload files so the installer template could be compiled without a full Windows package build. The NSIS compile completed successfully and wrote `Avogadro2-Setup.exe`.

## Notes

- Commit is signed off for the repository DCO.
- This intentionally keeps the change smaller than adopting the full NSIS MultiUser plugin flow discussed in the issue.