### PR TITLE
Fix broken link for 'Build' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Contributors Hall of Fame:
   [OpenChemistryLogo]: https://raw.githubusercontent.com/OpenChemistry/avogadrolibs/master/docs/OpenChemistry128.png "Open Chemistry"
   [Kitware]: https://kitware.com/ "Kitware, Inc."
   [Avogadro1]: https://avogadro.cc/ "Avogadro 1"
-  [Build]: https://two.avogadro.cc/develop/build/](https://avogadro.cc/develop/build.html "Building Avogadro"
+  [Build]: https://avogadro.cc/develop/build.html "Building Avogadro"
   [Install]: https://two.avogadro.cc/install/ "Installing Avogadro"
   [Contribution]: https://two.avogadro.cc/contrib/ "Contribution guide"
   [API]: https://two.avogadro.cc/develop/classlist/ "API documentation"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Contributors Hall of Fame:
   [OpenChemistryLogo]: https://raw.githubusercontent.com/OpenChemistry/avogadrolibs/master/docs/OpenChemistry128.png "Open Chemistry"
   [Kitware]: https://kitware.com/ "Kitware, Inc."
   [Avogadro1]: https://avogadro.cc/ "Avogadro 1"
-  [Build]: https://two.avogadro.cc/develop/build/ "Building Avogadro"
+  [Build]: https://two.avogadro.cc/develop/build/](https://avogadro.cc/develop/build.html "Building Avogadro"
   [Install]: https://two.avogadro.cc/install/ "Installing Avogadro"
   [Contribution]: https://two.avogadro.cc/contrib/ "Contribution guide"
   [API]: https://two.avogadro.cc/develop/classlist/ "API documentation"


### PR DESCRIPTION
`Build` link now points to `https://avogadro.cc/develop/build.html`, which looks correct.
