### PR TITLE
Add an optional Windows build with sentry / crashpad

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -179,7 +179,9 @@ jobs:
           VERSION=$(date +%Y-%m-%d)
         fi
 
-        mv Avogadro2-Setup.exe ../${{matrix.config.package}}-${VERSION}.exe
+        # NSIS OutFile is "<package>-Setup.exe", set from NSIS_OUTFILE in
+        # avogadro/CMakeLists.txt, so these two names have to stay in step.
+        mv ${{matrix.config.package}}-Setup.exe ../${{matrix.config.package}}-${VERSION}.exe
       working-directory: ${{ runner.workspace }}/build/
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -22,6 +22,13 @@ jobs:
   build:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
+    # Job level so that the symbol upload step can test them from its `if`:
+    # the secrets context is not available there, and a step's own env block
+    # is not reliably visible to its own condition.
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +40,22 @@ jobs:
             build_type: "Release",
             cmake_flags: "-DCMAKE_TOOLCHAIN_FILE=/c/vcpkg/scripts/buildsystems/vcpkg.cmake -DUSE_SYSTEM_EIGEN=ON -DUSE_SYSTEM_LIBARCHIVE=ON -DUSE_SYSTEM_LIBXML2=ON -DUSE_SYSTEM_ZLIB=ON",
             build_flags: "-j 2",
+            package: "Avogadro2",
+            sentry: false,
+          }
+        # Diagnostic build with Sentry crash reporting compiled in. Ships as a
+        # separate installer; the release build above gets no crash reporting.
+        # RelWithDebInfo rather than Release: MSVC Release passes no /Zi, so it
+        # emits no PDBs and every frame would come back as a raw address.
+        - {
+            name: "Windows Qt6 (Sentry)", artifact: "Win64-diagnostic.exe",
+            os: windows-latest,
+            cc: "cl", cxx: "cl",
+            build_type: "RelWithDebInfo",
+            cmake_flags: "-DCMAKE_TOOLCHAIN_FILE=/c/vcpkg/scripts/buildsystems/vcpkg.cmake -DUSE_SYSTEM_EIGEN=ON -DUSE_SYSTEM_LIBARCHIVE=ON -DUSE_SYSTEM_LIBXML2=ON -DUSE_SYSTEM_ZLIB=ON",
+            build_flags: "-j 2",
+            package: "Avogadro2-Diagnostic",
+            sentry: true,
           }
 
     steps:
@@ -69,14 +92,60 @@ jobs:
       run: |
         if [ ! -d "${{ runner.workspace }}/build" ]; then mkdir "${{ runner.workspace }}/build"; fi
         cd "${{ runner.workspace }}/build"
-        CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake $GITHUB_WORKSPACE/openchemistry ${{env.FEATURES}} -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} ${{matrix.config.cmake_flags}}
+        SENTRY_ARGS=""
+        if [ "${USE_SENTRY}" = "true" ]; then
+          # An unset SENTRY_DSN secret is fine: the build then reports itself
+          # as unavailable at runtime rather than failing to configure.
+          SENTRY_ARGS="-DUSE_SENTRY=ON -DSENTRY_DSN=${SENTRY_DSN} -DSENTRY_ENVIRONMENT=nightly"
+        fi
+        CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake $GITHUB_WORKSPACE/openchemistry ${{env.FEATURES}} -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} ${{matrix.config.cmake_flags}} $SENTRY_ARGS
       shell: bash
+      env:
+        USE_SENTRY: ${{ matrix.config.sentry }}
+        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
     - name: Build
       run: |
         CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake --build . --config ${{matrix.config.build_type}} ${{matrix.config.build_flags}}
       shell: bash
       working-directory: ${{ runner.workspace }}/build
+
+    # The crashpad binaries reach the prefix through crashpad's own install
+    # rules, which sentry-native does not drive directly when building shared.
+    # If they go missing the application still starts and simply never reports
+    # a crash, so fail here rather than shipping that.
+    - name: Verify crash handler binaries
+      if: matrix.config.sentry
+      shell: bash
+      working-directory: ${{ runner.workspace }}/build
+      run: |
+        status=0
+        for binary in avogadro2.exe sentry.dll crashpad_handler.exe crashpad_wer.dll; do
+          if [ -f "prefix/bin/$binary" ]; then
+            echo "found    prefix/bin/$binary"
+          else
+            echo "MISSING  prefix/bin/$binary"
+            status=1
+          fi
+        done
+        echo "--- debug symbols found ---"
+        find . -name '*.pdb' -not -path './Downloads/*' | head -40
+        exit $status
+
+    # Runs before packaging, which moves prefix/ out from under us. Sentry
+    # matches minidumps to symbols by debug ID, so this does not have to agree
+    # with the release name the application reports. Both avogadrolibs and
+    # avogadroapp symbols are needed: crashes usually land in a plugin or in
+    # Avogadro::Rendering rather than in avogadro2.exe itself.
+    - name: Upload debug symbols
+      if: matrix.config.sentry && env.SENTRY_AUTH_TOKEN != ''
+      shell: bash
+      working-directory: ${{ runner.workspace }}/build
+      run: |
+        curl -sL -o sentry-cli.exe \
+          https://downloads.sentry-cdn.com/sentry-cli/latest/sentry-cli-Windows-x86_64.exe
+        ./sentry-cli.exe debug-files upload --include-sources \
+          avogadroapp avogadrolibs prefix/bin
 
     - name: Create Windows Packages
       if: runner.os == 'Windows'
@@ -102,7 +171,7 @@ jobs:
           VERSION=$(date +%Y-%m-%d)
         fi
 
-        mv Avogadro2-Setup.exe ../Avogadro2-${VERSION}.exe
+        mv Avogadro2-Setup.exe ../${{matrix.config.package}}-${VERSION}.exe
       working-directory: ${{ runner.workspace }}/build/
       env:
         GH_TOKEN: ${{ github.token }}
@@ -115,8 +184,10 @@ jobs:
         path: ${{ runner.workspace }}/build/Avogadro2*.*
         name: ${{ matrix.config.artifact }}
 
+    # Release-only from here down. The diagnostic build is not signed under the
+    # release policy and gets no Store-identity MSIX package.
     - name: Sign Windows release
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+      if: ${{ !matrix.config.sentry && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') }}
       uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
       continue-on-error: true
       with:
@@ -129,7 +200,7 @@ jobs:
         output-artifact-directory: '../build/'
 
     - name: Create MSIX
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+      if: ${{ !matrix.config.sentry && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') }}
       shell: powershell
       run:
         # create MSIX
@@ -139,6 +210,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Upload MSIX
+      if: ${{ !matrix.config.sentry }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         path: ${{ runner.workspace }}/build/Avogadro2.msix

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -22,13 +22,6 @@ jobs:
   build:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
-    # Job level so that the symbol upload step can test them from its `if`:
-    # the secrets context is not available there, and a step's own env block
-    # is not reliably visible to its own condition.
-    env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     strategy:
       fail-fast: false
       matrix:
@@ -138,12 +131,27 @@ jobs:
     # avogadroapp symbols are needed: crashes usually land in a plugin or in
     # Avogadro::Rendering rather than in avogadro2.exe itself.
     - name: Upload debug symbols
-      if: matrix.config.sentry && env.SENTRY_AUTH_TOKEN != ''
+      if: matrix.config.sentry
       shell: bash
       working-directory: ${{ runner.workspace }}/build
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        # Pinned rather than "latest", to match how this workflow pins every
+        # action to a SHA. The checksum is of the released Windows binary.
+        SENTRY_CLI_VERSION: "3.6.2"
+        SENTRY_CLI_SHA256: "5c90cb0045cef3d3c36113c2aa21a7dcae11627d2d6e3098b679dea5b6681be3"
       run: |
-        curl -sL -o sentry-cli.exe \
-          https://downloads.sentry-cdn.com/sentry-cli/latest/sentry-cli-Windows-x86_64.exe
+        if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+          echo "SENTRY_AUTH_TOKEN is not set - skipping debug symbol upload."
+          echo "The diagnostic build is still produced; crashes just will not"
+          echo "symbolicate until the secret is configured."
+          exit 0
+        fi
+        curl -sSfL -o sentry-cli.exe \
+          "https://downloads.sentry-cdn.com/sentry-cli/${SENTRY_CLI_VERSION}/sentry-cli-Windows-x86_64.exe"
+        echo "${SENTRY_CLI_SHA256}  sentry-cli.exe" | sha256sum --check --strict
         ./sentry-cli.exe debug-files upload --include-sources \
           avogadroapp avogadrolibs prefix/bin
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,19 @@ endif()
 
 option(Avogadro_ENABLE_RPC "Enable RPC server" ON)
 
+# Crash reporting via sentry-native, used only by the separate Windows
+# diagnostic build. Off everywhere else.
+if(WIN32)
+  option(USE_SENTRY "Enable Sentry crash reporting (diagnostic builds)" OFF)
+  set(SENTRY_DSN "" CACHE STRING "Sentry DSN for crash reports")
+  set(SENTRY_ENVIRONMENT "nightly" CACHE STRING
+    "Sentry environment name reported with each event")
+elseif(USE_SENTRY)
+  message("Disabling USE_SENTRY - it is only supported on Windows.")
+  set(USE_SENTRY OFF CACHE BOOL
+    "Enable Sentry crash reporting (diagnostic builds)" FORCE)
+endif()
+
 add_subdirectory(avogadro)
 
 option(BUILD_DOCUMENTATION "Build project documentation" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(WIN32)
   set(SENTRY_ENVIRONMENT "nightly" CACHE STRING
     "Sentry environment name reported with each event")
 elseif(USE_SENTRY)
-  message("Disabling USE_SENTRY - it is only supported on Windows.")
+  message(WARNING "Disabling USE_SENTRY - it is only supported on Windows.")
   set(USE_SENTRY OFF CACHE BOOL
     "Enable Sentry crash reporting (diagnostic builds)" FORCE)
 endif()

--- a/avogadro/CMakeLists.txt
+++ b/avogadro/CMakeLists.txt
@@ -57,7 +57,9 @@ set(avogadro_srcs
 )
 
 if(USE_SENTRY)
-  list(APPEND avogadro_srcs crashreporter.cpp crashreporter.h)
+  list(APPEND avogadro_srcs
+    crashreporter.cpp crashreporter.h
+    crashreportdialog.cpp crashreportdialog.h)
 endif()
 
 qt_wrap_ui(ui_srcs
@@ -208,6 +210,26 @@ elseif(WIN32)
   install(FILES "icons/Avogadro2_150.png" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons")
   install(FILES "icons/Avogadro2_310.png" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons")
 
+  # Installer identity. The diagnostic build is meant to install beside a
+  # release install rather than on top of it, so everything derived from
+  # APP_NAME has to differ: install directory, Start Menu group, shortcuts and
+  # the uninstall registry keys. APP_EXE deliberately does not differ - the
+  # executable keeps its name.
+  if(USE_SENTRY)
+    set(NSIS_APP_NAME "Avogadro2 Diagnostic")
+    set(NSIS_OUTFILE "Avogadro2-Diagnostic-Setup.exe")
+    # File associations are global, shared state. The ProgIDs in the NSIS
+    # script are fixed strings rather than APP_NAME-derived, so registering
+    # them here would repoint .cml and friends at this build, and uninstalling
+    # would delete them out from under a release install. Leave them alone -
+    # a tester's normal Avogadro stays the file handler.
+    set(NSIS_FILE_ASSOCIATIONS "")
+  else()
+    set(NSIS_APP_NAME "Avogadro2")
+    set(NSIS_OUTFILE "Avogadro2-Setup.exe")
+    set(NSIS_FILE_ASSOCIATIONS "!define REGISTER_FILE_ASSOCIATIONS")
+  endif()
+
   # configure the NSI and MSIX installer scripts
   configure_file("${AvogadroApp_SOURCE_DIR}/cmake/avogadro2.nsi.in" "${CMAKE_INSTALL_PREFIX}/avogadro2.nsi" @ONLY)
   configure_file("${AvogadroApp_SOURCE_DIR}/cmake/AppxManifest.xml.in" "${CMAKE_INSTALL_PREFIX}/AppxManifest.xml" @ONLY)
@@ -235,6 +257,11 @@ if(Avogadro_ENABLE_RPC)
 endif()
 if(USE_SENTRY)
   target_link_libraries(avogadro sentry::sentry)
+  # sentry.dll, crashpad_handler.exe and crashpad_wer.dll need no install rule
+  # here: sentry-native installs them into the shared prefix already, which is
+  # the same bin directory the installer packages.
+  install(FILES "${AvogadroApp_SOURCE_DIR}/cmake/COPYING.sentry"
+    DESTINATION "${INSTALL_DOC_DIR}/avogadro2")
 endif()
 if(APPLE)
   set_target_properties(avogadro PROPERTIES OUTPUT_NAME ${MACOSX_BUNDLE_NAME})

--- a/avogadro/CMakeLists.txt
+++ b/avogadro/CMakeLists.txt
@@ -30,6 +30,13 @@ if(QT_VERSION EQUAL 6)
     REQUIRED)
 endif()
 
+if(USE_SENTRY)
+  find_package(sentry REQUIRED)
+  # Drives the #cmakedefine in avogadroappconfig.h.in, which is the single
+  # source of truth for whether crash reporting is compiled in.
+  set(AVOGADRO_USE_SENTRY ON)
+endif()
+
 configure_file(avogadroappconfig.h.in avogadroappconfig.h)
 
 set(avogadro_srcs
@@ -43,6 +50,10 @@ set(avogadro_srcs
   tooltipfilter.cpp
   viewfactory.cpp
 )
+
+if(USE_SENTRY)
+  list(APPEND avogadro_srcs crashreporter.cpp crashreporter.h)
+endif()
 
 qt_wrap_ui(ui_srcs
   aboutdialog.ui
@@ -216,6 +227,9 @@ set_target_properties(avogadro PROPERTIES AUTOMOC TRUE)
 target_link_libraries(avogadro Avogadro::QtOpenGL Avogadro::QtGui Avogadro::QtPlugins)
 if(Avogadro_ENABLE_RPC)
   target_link_libraries(avogadro AvogadroRPC)
+endif()
+if(USE_SENTRY)
+  target_link_libraries(avogadro sentry::sentry)
 endif()
 if(APPLE)
   set_target_properties(avogadro PROPERTIES OUTPUT_NAME ${MACOSX_BUNDLE_NAME})

--- a/avogadro/CMakeLists.txt
+++ b/avogadro/CMakeLists.txt
@@ -32,9 +32,14 @@ endif()
 
 if(USE_SENTRY)
   find_package(sentry REQUIRED)
-  # Drives the #cmakedefine in avogadroappconfig.h.in, which is the single
-  # source of truth for whether crash reporting is compiled in.
+  # These drive the #cmakedefine lines in avogadroappconfig.h.in, which is the
+  # single source of truth for how crash reporting is compiled in. The names
+  # have to match the macros being defined - #cmakedefine tests the variable
+  # named after it, not the one substituted into the value - so the SENTRY_*
+  # cache entries are copied across here rather than used directly.
   set(AVOGADRO_USE_SENTRY ON)
+  set(AVOGADRO_SENTRY_DSN "${SENTRY_DSN}")
+  set(AVOGADRO_SENTRY_ENVIRONMENT "${SENTRY_ENVIRONMENT}")
 endif()
 
 configure_file(avogadroappconfig.h.in avogadroappconfig.h)

--- a/avogadro/aboutdialog.cpp
+++ b/avogadro/aboutdialog.cpp
@@ -5,6 +5,7 @@
 
 #include "aboutdialog.h"
 #include "avogadroappconfig.h"
+#include "crashreporter.h"
 #include "ui_aboutdialog.h"
 
 #include <QSslSocket>
@@ -35,7 +36,16 @@ AboutDialog::AboutDialog(QWidget* parent_)
   m_ui->sslVersionLabel->setText(html.arg("10").arg(tr("SSL Version:")));
 
   // Add the version numbers
-  m_ui->version->setText(html.arg("20").arg(AvogadroApp_VERSION));
+  // Mark the diagnostic build, which ships crash reporting and can be
+  // installed alongside a normal Avogadro - otherwise there is no way to tell
+  // the two apart once they are running. Asking CrashReporter rather than the
+  // build macro keeps this in step with the rest of the application: a build
+  // made with USE_SENTRY but no DSN configured reports nothing, and so should
+  // not call itself a diagnostic build either.
+  QString versionText(AvogadroApp_VERSION);
+  if (CrashReporter::isAvailable())
+    versionText = tr("%1 (Diagnostic)").arg(versionText);
+  m_ui->version->setText(html.arg("20").arg(versionText));
   m_ui->libsVersion->setText(html.arg("10").arg(version()));
   m_ui->qtVersion->setText(html.arg("10").arg(qVersion()));
   m_ui->sslVersion->setText(

--- a/avogadro/avogadro.cpp
+++ b/avogadro/avogadro.cpp
@@ -28,6 +28,7 @@
 
 #include "application.h"
 #include "avogadroappconfig.h"
+#include "crashreporter.h"
 #include "mainwindow.h"
 
 #ifdef Q_OS_MAC
@@ -158,6 +159,7 @@ int main(int argc, char* argv[])
   // We need to ensure desktop OpenGL is loaded for our rendering.
   QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
 
+#ifndef AVOGADRO_USE_SENTRY
   // remove the previous log file
   QString writableDocs =
     QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
@@ -167,6 +169,14 @@ int main(int argc, char* argv[])
   // install the message handler (goes to Documents / avogadro2.log)
   qInstallMessageHandler(myMessageOutput);
 #endif
+#endif
+
+  // Start crash reporting before the QApplication instance exists, so that a
+  // crash while Qt loads its platform plugin is still caught. This also has to
+  // come after the message handler above: the Qt integration chains to
+  // whichever handler was installed first, so installing one afterwards would
+  // silently discard every breadcrumb.
+  Avogadro::CrashReporterGuard crashReporterGuard;
 
   // output the version information
   qDebug() << "Avogadroapp version: " << AvogadroApp_VERSION;
@@ -371,6 +381,14 @@ int main(int argc, char* argv[])
 #endif
     } else if (*it == "--disable-settings") {
       disableSettings = true;
+    } else if (*it == "--crash-test") {
+#ifdef AVOGADRO_USE_SENTRY
+      Avogadro::CrashReporter::triggerTestCrash();
+#else
+      qWarning("Avogadro called with --crash-test but crash reporting is "
+               "disabled.");
+      return EXIT_FAILURE;
+#endif
     } else if (it->startsWith("-")) {
       qWarning("Unknown command line option '%s'", qPrintable(*it));
       return EXIT_FAILURE;

--- a/avogadro/avogadro.cpp
+++ b/avogadro/avogadro.cpp
@@ -404,6 +404,10 @@ int main(int argc, char* argv[])
 #endif
   window.show();
 
+  // On a diagnostic build, ask about crash reporting the first time it runs.
+  // A no-op everywhere else.
+  Avogadro::CrashReporter::promptForConsentIfNeeded(&window);
+
 #ifdef Avogadro_ENABLE_RPC
   // create rpc listener
   Avogadro::RpcListener listener;

--- a/avogadro/avogadroappconfig.h.in
+++ b/avogadro/avogadroappconfig.h.in
@@ -1,7 +1,13 @@
 #cmakedefine AvogadroApp_VERSION "@AvogadroApp_VERSION@"
 
 /* Crash reporting via sentry-native. Only the Windows diagnostic build sets
-   these; every other build leaves them undefined. */
+   these; every other build leaves them undefined.
+
+   The cmakedefine directive below tests the variable named right after it, not
+   the one substituted into the value, so these have to be driven by
+   AVOGADRO_SENTRY_* variables rather than by the SENTRY_* cache entries.
+   (Do not write that directive's literal token in this comment - configure_file
+   rewrites it even here.) */
 #cmakedefine AVOGADRO_USE_SENTRY
-#cmakedefine AVOGADRO_SENTRY_DSN "@SENTRY_DSN@"
-#cmakedefine AVOGADRO_SENTRY_ENVIRONMENT "@SENTRY_ENVIRONMENT@"
+#cmakedefine AVOGADRO_SENTRY_DSN "@AVOGADRO_SENTRY_DSN@"
+#cmakedefine AVOGADRO_SENTRY_ENVIRONMENT "@AVOGADRO_SENTRY_ENVIRONMENT@"

--- a/avogadro/avogadroappconfig.h.in
+++ b/avogadro/avogadroappconfig.h.in
@@ -1,1 +1,7 @@
 #cmakedefine AvogadroApp_VERSION "@AvogadroApp_VERSION@"
+
+/* Crash reporting via sentry-native. Only the Windows diagnostic build sets
+   these; every other build leaves them undefined. */
+#cmakedefine AVOGADRO_USE_SENTRY
+#cmakedefine AVOGADRO_SENTRY_DSN "@SENTRY_DSN@"
+#cmakedefine AVOGADRO_SENTRY_ENVIRONMENT "@SENTRY_ENVIRONMENT@"

--- a/avogadro/crashreportdialog.cpp
+++ b/avogadro/crashreportdialog.cpp
@@ -1,0 +1,92 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#include "crashreportdialog.h"
+
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QDialogButtonBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QVBoxLayout>
+
+namespace Avogadro {
+
+CrashReportDialog::CrashReportDialog(bool firstRun, QWidget* parent)
+  : QDialog(parent)
+  , m_firstRun(firstRun)
+  , m_sendReports(nullptr)
+{
+  setWindowTitle(tr("Crash Reporting"));
+  setMinimumWidth(480);
+
+  auto* layout = new QVBoxLayout(this);
+
+  auto* intro = new QLabel(
+    tr("This is a diagnostic build of Avogadro. It can send a report to the "
+       "developers when Avogadro crashes, which helps us fix crashes we "
+       "cannot reproduce ourselves."),
+    this);
+  intro->setWordWrap(true);
+  layout->addWidget(intro);
+
+  // Be straight about what a minidump is. It is a snapshot of the process,
+  // not a curated set of fields, and it cannot be filtered before it is
+  // written - so promising anonymity here would not be truthful.
+  auto* detail = new QLabel(
+    tr("A crash report contains a snapshot of Avogadro's memory at the moment "
+       "it failed, along with your operating system, graphics driver and "
+       "Avogadro version, and a log of recent activity. That memory snapshot "
+       "makes the report useful, but it may incidentally include "
+       "fragments of what you were working on, such as part of a file name or "
+       "a molecule you had open."),
+    this);
+  detail->setWordWrap(true);
+  layout->addWidget(detail);
+
+  // Only worth saying on first run - in the settings dialog the user is
+  // already looking at the place they would be sent to.
+  if (m_firstRun) {
+    auto* control = new QLabel(
+      tr("Nothing is sent unless you agree. You can change this at any time "
+         "under Help \342\206\222 Crash Reporting."),
+      this);
+    control->setWordWrap(true);
+    layout->addWidget(control);
+  }
+
+  QDialogButtonBox* buttons = nullptr;
+  if (m_firstRun) {
+    // No checkbox and no default button: first run is a deliberate choice.
+    buttons = new QDialogButtonBox(this);
+    buttons->addButton(tr("Send Crash Reports"), QDialogButtonBox::AcceptRole);
+    buttons->addButton(tr("Don't Send"), QDialogButtonBox::RejectRole);
+  } else {
+    m_sendReports =
+      new QCheckBox(tr("Send crash reports to the Avogadro developers"), this);
+    layout->addSpacing(6);
+    layout->addWidget(m_sendReports);
+    buttons = new QDialogButtonBox(
+      QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+  }
+
+  layout->addWidget(buttons);
+  connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
+bool CrashReportDialog::consentGiven() const
+{
+  // On first run the answer is carried by which button was pressed, so the
+  // caller reads it from the dialog result instead.
+  return m_sendReports != nullptr && m_sendReports->isChecked();
+}
+
+void CrashReportDialog::setConsentGiven(bool consentGiven)
+{
+  if (m_sendReports != nullptr)
+    m_sendReports->setChecked(consentGiven);
+}
+
+} // end namespace Avogadro

--- a/avogadro/crashreportdialog.h
+++ b/avogadro/crashreportdialog.h
@@ -1,0 +1,45 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_CRASHREPORTDIALOG_H
+#define AVOGADRO_CRASHREPORTDIALOG_H
+
+#include <QtWidgets/QDialog>
+
+class QCheckBox;
+
+namespace Avogadro {
+
+/**
+ * @class CrashReportDialog crashreportdialog.h
+ * @brief Asks the user whether crash reports may be sent.
+ *
+ * Used in two modes. On first run it presents an explicit choice, with no
+ * default and no way to dismiss it without deciding. Afterwards it is reached
+ * from Help and shows a checkbox reflecting the current setting.
+ *
+ * This is only built when the application is configured with USE_SENTRY.
+ */
+class CrashReportDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit CrashReportDialog(bool firstRun, QWidget* parent = nullptr);
+
+  /** @return true if the user wants crash reports sent */
+  bool consentGiven() const;
+
+  /** Set the state shown when the dialog opens. Ignored on first run. */
+  void setConsentGiven(bool consentGiven);
+
+private:
+  bool m_firstRun;
+  QCheckBox* m_sendReports;
+};
+
+} // end namespace Avogadro
+
+#endif // AVOGADRO_CRASHREPORTDIALOG_H

--- a/avogadro/crashreporter.cpp
+++ b/avogadro/crashreporter.cpp
@@ -22,6 +22,17 @@
 #include <QtCore/QSettings>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QString>
+#include <QtCore/QStringList>
+
+#include <avogadro/core/version.h>
+#include <avogadro/qtgui/extensionplugin.h>
+#include <avogadro/qtgui/sceneplugin.h>
+#include <avogadro/qtgui/toolplugin.h>
+#include <avogadro/qtplugins/pluginmanager.h>
+
+#include <QtGui/QOpenGLContext>
+#include <QtGui/QOpenGLFunctions>
+#include <QtOpenGLWidgets/QOpenGLWidget>
 
 #include <sentry.h>
 
@@ -225,6 +236,50 @@ QString crashHandlerPath()
 #endif
 }
 
+/// Store @a names as a single readable field of @a parent.
+void setStringList(sentry_value_t parent, const char* key,
+                   const QStringList& names)
+{
+  const QString joined = names.join(QStringLiteral(", "));
+  sentry_value_set_by_key(parent, key,
+                          sentry_value_new_string(joined.toUtf8().constData()));
+}
+
+/// glGetString can return null; sentry_set_tag needs a real string. Handing
+/// the driver's own pointer straight to sentry avoids a QString round trip.
+const char* glString(QOpenGLFunctions* gl, GLenum name)
+{
+  const GLubyte* value = gl->glGetString(name);
+  return value == nullptr ? "" : reinterpret_cast<const char*>(value);
+}
+
+/// Tags rather than context, so these can be grouped and filtered on: "every
+/// crash from this driver" is the question worth asking.
+void recordOpenGLContextInfo(QOpenGLWidget* glWidget)
+{
+  glWidget->makeCurrent();
+  if (QOpenGLContext* context = QOpenGLContext::currentContext()) {
+    QOpenGLFunctions* gl = context->functions();
+    sentry_set_tag("gl.vendor", glString(gl, GL_VENDOR));
+    sentry_set_tag("gl.renderer", glString(gl, GL_RENDERER));
+    sentry_set_tag("gl.version", glString(gl, GL_VERSION));
+  }
+  glWidget->doneCurrent();
+}
+
+/// Sorted identifiers of every loaded plugin of one kind.
+template<typename Factory>
+QStringList pluginIdentifiers()
+{
+  QStringList names;
+  const auto factories =
+    QtPlugins::PluginManager::instance()->pluginFactories<Factory>();
+  for (Factory* factory : factories)
+    names << factory->identifier();
+  names.sort();
+  return names;
+}
+
 void applyConsent(bool consentGiven)
 {
   if (!sentryInitialized)
@@ -309,6 +364,10 @@ void CrashReporter::initialize()
 
   sentryInitialized = true;
 
+  // Versions worth having on every report, whatever else we manage to attach.
+  sentry_set_tag("qt.version", qVersion());
+  sentry_set_tag("avogadrolibs.version", Avogadro::version());
+
   // Carry over the decision the user made in an earlier run.
   applyConsent(hasConsent());
 #endif
@@ -373,6 +432,44 @@ void CrashReporter::showSettingsDialog(QWidget* parentWidget)
   dialog.setConsentGiven(hasConsent());
   if (dialog.exec() == QDialog::Accepted)
     setConsent(dialog.consentGiven());
+}
+
+void CrashReporter::attachSessionContext(QOpenGLWidget* glWidget)
+{
+  if (!sentryInitialized)
+    return;
+
+  // The driver strings can only be read once there is a context, so wait for
+  // the first swapped frame rather than querying now.
+  if (glWidget != nullptr) {
+    QObject::connect(
+      glWidget, &QOpenGLWidget::frameSwapped, glWidget,
+      [glWidget]() { recordOpenGLContextInfo(glWidget); },
+      Qt::SingleShotConnection);
+  }
+
+  // A stack trace ending inside a plugin library is otherwise hard to tell
+  // apart from one in the core.
+  sentry_value_t plugins = sentry_value_new_object();
+  setStringList(plugins, "scene",
+                pluginIdentifiers<QtGui::ScenePluginFactory>());
+  setStringList(plugins, "tool", pluginIdentifiers<QtGui::ToolPluginFactory>());
+  setStringList(plugins, "extension",
+                pluginIdentifiers<QtGui::ExtensionPluginFactory>());
+  sentry_set_context("plugins", plugins);
+}
+
+void CrashReporter::addBreadcrumb(const QString& category,
+                                  const QString& message)
+{
+  if (!sentryInitialized)
+    return;
+
+  sentry_value_t crumb =
+    sentry_value_new_breadcrumb("default", message.toUtf8().constData());
+  sentry_value_set_by_key(
+    crumb, "category", sentry_value_new_string(category.toUtf8().constData()));
+  sentry_add_breadcrumb(crumb);
 }
 
 void CrashReporter::triggerTestCrash()

--- a/avogadro/crashreporter.cpp
+++ b/avogadro/crashreporter.cpp
@@ -1,0 +1,336 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+// This file is only compiled when the build is configured with USE_SENTRY.
+// Builds without it use the inline no-op definitions in crashreporter.h.
+
+#include "crashreporter.h"
+
+#ifndef AVOGADRO_USE_SENTRY
+// Without this the inline no-op definitions in the header are also in scope,
+// and the failure is a wall of redefinition errors rather than a useful one.
+#error "crashreporter.cpp requires a build configured with USE_SENTRY"
+#endif
+
+#include <QtCore/QDebug>
+#include <QtCore/QDir>
+#include <QtCore/QFileInfo>
+#include <QtCore/QSettings>
+#include <QtCore/QStandardPaths>
+#include <QtCore/QString>
+
+#include <sentry.h>
+
+#include <cctype>
+#include <string>
+#include <vector>
+
+#ifdef Q_OS_WIN
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+// Set by CMake, but fall back to something honest for a local build that
+// forgot to pass one.
+#ifndef AVOGADRO_SENTRY_ENVIRONMENT
+#define AVOGADRO_SENTRY_ENVIRONMENT "development"
+#endif
+
+namespace Avogadro {
+
+namespace {
+
+const char* consentKey = "crashReporting/consent";
+const char* consentAskedKey = "crashReporting/consentAsked";
+
+bool sentryInitialized = false;
+
+/// Lowercased spellings of the user's home directory, used to strip it out of
+/// outgoing events. Computed once in initialize() because the before_send
+/// callback can run inside an exception filter, where calling into Qt is not
+/// safe. Both separator styles are kept: Qt reports '/' while the Windows APIs
+/// and most driver messages report '\'.
+std::vector<std::string> homeDirectoryNeedles;
+
+constexpr char homeReplacement[] = "<user home>";
+constexpr size_t homeReplacementLength = sizeof(homeReplacement) - 1;
+
+std::string toLower(const std::string& text)
+{
+  std::string result(text);
+  for (char& character : result) {
+    character =
+      static_cast<char>(std::tolower(static_cast<unsigned char>(character)));
+  }
+  return result;
+}
+
+/// Replace every spelling of the user's home directory in @a text.
+/// @return true if @a text was modified.
+bool scrubString(std::string& text)
+{
+  if (homeDirectoryNeedles.empty() || text.empty())
+    return false;
+
+  // Windows paths are case insensitive, so match on a lowercased copy and
+  // splice the original. The copy is only made when there is something to
+  // search, keeping the common "nothing to do" path allocation free.
+  std::string lowered = toLower(text);
+  bool modified = false;
+
+  for (const std::string& needle : homeDirectoryNeedles) {
+    std::string::size_type at = lowered.find(needle);
+    while (at != std::string::npos) {
+      text.replace(at, needle.size(), homeReplacement);
+      lowered.replace(at, needle.size(), homeReplacement);
+      modified = true;
+      at = lowered.find(needle, at + homeReplacementLength);
+    }
+  }
+
+  return modified;
+}
+
+/// Scrub the string stored at @a key of @a parent, if there is one.
+void scrubValueAtKey(sentry_value_t parent, const char* key)
+{
+  sentry_value_t value = sentry_value_get_by_key(parent, key);
+  if (sentry_value_get_type(value) != SENTRY_VALUE_TYPE_STRING)
+    return;
+
+  const char* raw = sentry_value_as_string(value);
+  if (raw == nullptr)
+    return;
+
+  std::string text(raw);
+  if (!scrubString(text))
+    return;
+
+  sentry_value_set_by_key(parent, key, sentry_value_new_string(text.c_str()));
+}
+
+/// Strip the user's home directory out of the fields we populate.
+///
+/// Note the limits of this, which are a property of the crashpad backend
+/// rather than of this function: for an actual crash the event handed to
+/// before_send is empty, because the exception and stack trace are rebuilt
+/// server side from the minidump. So this only cleans non-crash events and the
+/// breadcrumbs riding along with them. Anything the minidump itself contains
+/// has to be handled by the server side scrubbing rules on the Sentry project.
+sentry_value_t scrubEvent(sentry_value_t event, void* hint, void* userData)
+{
+  Q_UNUSED(hint);
+  Q_UNUSED(userData);
+
+  // Breadcrumbs are where user paths actually turn up, since the Qt
+  // integration turns every qWarning into one.
+  sentry_value_t breadcrumbs = sentry_value_get_by_key(event, "breadcrumbs");
+  sentry_value_t values = sentry_value_get_by_key(breadcrumbs, "values");
+  if (sentry_value_get_type(values) != SENTRY_VALUE_TYPE_LIST)
+    values = breadcrumbs;
+
+  if (sentry_value_get_type(values) == SENTRY_VALUE_TYPE_LIST) {
+    const size_t count = sentry_value_get_length(values);
+    for (size_t i = 0; i < count; ++i)
+      scrubValueAtKey(sentry_value_get_by_index(values, i), "message");
+  }
+
+  scrubValueAtKey(event, "message");
+
+  sentry_value_t logentry = sentry_value_get_by_key(event, "logentry");
+  if (sentry_value_get_type(logentry) == SENTRY_VALUE_TYPE_OBJECT)
+    scrubValueAtKey(logentry, "message");
+
+  return event;
+}
+
+void rememberHomeDirectory()
+{
+  homeDirectoryNeedles.clear();
+
+  const QString home = QDir::homePath();
+  if (home.isEmpty())
+    return;
+
+  const QString slashes = QDir::fromNativeSeparators(home);
+  const QString backslashes = QDir::toNativeSeparators(home);
+
+  homeDirectoryNeedles.push_back(toLower(slashes.toStdString()));
+  if (backslashes != slashes)
+    homeDirectoryNeedles.push_back(toLower(backslashes.toStdString()));
+}
+
+/// Absolute path to the crashpad handler, which lives next to our executable.
+///
+/// This deliberately avoids QCoreApplication::applicationDirPath(), because
+/// the crash handler is started before the QApplication instance exists.
+QString crashHandlerPath()
+{
+#ifdef Q_OS_WIN
+  std::vector<wchar_t> buffer(MAX_PATH);
+  for (;;) {
+    const DWORD length = GetModuleFileNameW(nullptr, buffer.data(),
+                                            static_cast<DWORD>(buffer.size()));
+    if (length == 0)
+      return QString();
+    // On truncation the call returns the buffer size it was given.
+    if (static_cast<size_t>(length) < buffer.size())
+      break;
+    buffer.resize(buffer.size() * 2);
+  }
+
+  const QString executable = QString::fromWCharArray(buffer.data());
+  return QFileInfo(executable)
+    .absoluteDir()
+    .absoluteFilePath("crashpad_handler.exe");
+#else
+  // Crash reporting is Windows only for now.
+  return QString();
+#endif
+}
+
+void applyConsent(bool consentGiven)
+{
+  if (!sentryInitialized)
+    return;
+
+  if (consentGiven)
+    sentry_user_consent_give();
+  else
+    sentry_user_consent_revoke();
+}
+
+} // end anonymous namespace
+
+bool CrashReporter::isAvailable()
+{
+#ifdef AVOGADRO_SENTRY_DSN
+  return true;
+#else
+  // Built with USE_SENTRY but no DSN was configured, so there is nowhere to
+  // send anything.
+  return false;
+#endif
+}
+
+void CrashReporter::initialize()
+{
+#ifdef AVOGADRO_SENTRY_DSN
+  if (sentryInitialized || !isAvailable())
+    return;
+
+  const QString dataLocation =
+    QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+  if (dataLocation.isEmpty()) {
+    qWarning("Crash reporting disabled: no writable data location.");
+    return;
+  }
+
+  const QString databasePath =
+    QDir(dataLocation).absoluteFilePath("crashpad-db");
+  QDir().mkpath(databasePath);
+
+  const QString handlerPath = crashHandlerPath();
+  if (handlerPath.isEmpty() || !QFileInfo::exists(handlerPath)) {
+    qWarning("Crash reporting disabled: crashpad handler was not found.");
+    return;
+  }
+
+  rememberHomeDirectory();
+
+  sentry_options_t* options = sentry_options_new();
+  sentry_options_set_dsn(options, AVOGADRO_SENTRY_DSN);
+
+#ifdef Q_OS_WIN
+  // The wide character setters matter here: Windows profile paths regularly
+  // contain non-ASCII characters, and the narrow variants would mangle them,
+  // leaving the handler silently unable to write its database.
+  const std::wstring database =
+    QDir::toNativeSeparators(databasePath).toStdWString();
+  const std::wstring handler =
+    QDir::toNativeSeparators(handlerPath).toStdWString();
+  sentry_options_set_database_pathw(options, database.c_str());
+  sentry_options_set_handler_pathw(options, handler.c_str());
+#else
+  sentry_options_set_database_path(options, databasePath.toUtf8().constData());
+  sentry_options_set_handler_path(options, handlerPath.toUtf8().constData());
+#endif
+
+  // Must match the release that sentry-cli uploads debug symbols under, or
+  // nothing will symbolicate.
+  sentry_options_set_release(options, "avogadro2@" AvogadroApp_VERSION);
+  sentry_options_set_environment(options, AVOGADRO_SENTRY_ENVIRONMENT);
+
+  // Reports are collected locally but held back until consent is given.
+  sentry_options_set_require_user_consent(options, 1);
+  sentry_options_set_max_breadcrumbs(options, 50);
+  sentry_options_set_before_send(options, scrubEvent, nullptr);
+
+  if (sentry_init(options) != 0) {
+    qWarning("Crash reporting could not be started.");
+    return;
+  }
+
+  sentryInitialized = true;
+
+  // Carry over the decision the user made in an earlier run.
+  applyConsent(hasConsent());
+#endif
+}
+
+void CrashReporter::shutdown()
+{
+  if (!sentryInitialized)
+    return;
+
+  sentryInitialized = false;
+  sentry_close();
+}
+
+bool CrashReporter::hasConsent()
+{
+  if (!isAvailable())
+    return false;
+
+  QSettings settings;
+  return settings.value(consentKey, false).toBool();
+}
+
+bool CrashReporter::consentRequested()
+{
+  if (!isAvailable())
+    return false;
+
+  QSettings settings;
+  return settings.value(consentAskedKey, false).toBool();
+}
+
+void CrashReporter::setConsent(bool consentGiven)
+{
+  if (!isAvailable())
+    return;
+
+  QSettings settings;
+  settings.setValue(consentKey, consentGiven);
+  settings.setValue(consentAskedKey, true);
+
+  applyConsent(consentGiven);
+}
+
+void CrashReporter::triggerTestCrash()
+{
+  // Deliberate null dereference. This is the one place in the application
+  // that is meant to crash: it exists to prove the handler, the symbols and
+  // the upload path all work, and is only reachable via --crash-test.
+  volatile int* pointer = nullptr;
+  *pointer = 0;
+}
+
+} // end namespace Avogadro

--- a/avogadro/crashreporter.cpp
+++ b/avogadro/crashreporter.cpp
@@ -8,6 +8,8 @@
 
 #include "crashreporter.h"
 
+#include "crashreportdialog.h"
+
 #ifndef AVOGADRO_USE_SENTRY
 // Without this the inline no-op definitions in the header are also in scope,
 // and the failure is a wall of redefinition errors rather than a useful one.
@@ -349,6 +351,28 @@ void CrashReporter::setConsent(bool consentGiven)
   settings.setValue(consentAskedKey, true);
 
   applyConsent(consentGiven);
+}
+
+void CrashReporter::promptForConsentIfNeeded(QWidget* parentWidget)
+{
+  if (!isAvailable() || consentRequested())
+    return;
+
+  // First run has no checkbox: the answer is which button was pressed, and
+  // either answer counts as having been asked.
+  CrashReportDialog dialog(true, parentWidget);
+  setConsent(dialog.exec() == QDialog::Accepted);
+}
+
+void CrashReporter::showSettingsDialog(QWidget* parentWidget)
+{
+  if (!isAvailable())
+    return;
+
+  CrashReportDialog dialog(false, parentWidget);
+  dialog.setConsentGiven(hasConsent());
+  if (dialog.exec() == QDialog::Accepted)
+    setConsent(dialog.consentGiven());
 }
 
 void CrashReporter::triggerTestCrash()

--- a/avogadro/crashreporter.cpp
+++ b/avogadro/crashreporter.cpp
@@ -62,14 +62,43 @@ std::vector<std::string> homeDirectoryNeedles;
 constexpr char homeReplacement[] = "<user home>";
 constexpr size_t homeReplacementLength = sizeof(homeReplacement) - 1;
 
+char toLowerChar(char character)
+{
+  return static_cast<char>(std::tolower(static_cast<unsigned char>(character)));
+}
+
 std::string toLower(const std::string& text)
 {
   std::string result(text);
-  for (char& character : result) {
-    character =
-      static_cast<char>(std::tolower(static_cast<unsigned char>(character)));
-  }
+  for (char& character : result)
+    character = toLowerChar(character);
   return result;
+}
+
+/// Case insensitive search for @a needle within @a text, starting at @a from.
+/// @a needle must already be lowercased. Allocates nothing, which matters
+/// because this runs on the before_send path.
+std::string::size_type findLowered(const std::string& text,
+                                   const std::string& needle,
+                                   std::string::size_type from)
+{
+  if (needle.empty() || text.size() < needle.size())
+    return std::string::npos;
+
+  const std::string::size_type last = text.size() - needle.size();
+  for (std::string::size_type at = from; at <= last; ++at) {
+    bool matched = true;
+    for (std::string::size_type i = 0; i < needle.size(); ++i) {
+      if (toLowerChar(text[at + i]) != needle[i]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched)
+      return at;
+  }
+
+  return std::string::npos;
 }
 
 /// Replace every spelling of the user's home directory in @a text.
@@ -79,19 +108,17 @@ bool scrubString(std::string& text)
   if (homeDirectoryNeedles.empty() || text.empty())
     return false;
 
-  // Windows paths are case insensitive, so match on a lowercased copy and
-  // splice the original. The copy is only made when there is something to
-  // search, keeping the common "nothing to do" path allocation free.
-  std::string lowered = toLower(text);
+  // Windows paths are case insensitive, so compare that way. The search
+  // itself allocates nothing, so a string with no home directory in it - by
+  // far the common case - costs only the scan.
   bool modified = false;
 
   for (const std::string& needle : homeDirectoryNeedles) {
-    std::string::size_type at = lowered.find(needle);
+    std::string::size_type at = findLowered(text, needle, 0);
     while (at != std::string::npos) {
       text.replace(at, needle.size(), homeReplacement);
-      lowered.replace(at, needle.size(), homeReplacement);
       modified = true;
-      at = lowered.find(needle, at + homeReplacementLength);
+      at = findLowered(text, needle, at + homeReplacementLength);
     }
   }
 

--- a/avogadro/crashreporter.h
+++ b/avogadro/crashreporter.h
@@ -8,6 +8,8 @@
 
 #include "avogadroappconfig.h"
 
+class QWidget;
+
 namespace Avogadro {
 
 /**
@@ -51,6 +53,17 @@ public:
 
   /** Record the user's decision and apply it to the running handler. */
   static void setConsent(bool consentGiven);
+
+  /**
+   * Ask the user about crash reporting, if they have not been asked before.
+   *
+   * Call this once the main window is up. Does nothing on a build without
+   * crash reporting, or once the question has been answered.
+   */
+  static void promptForConsentIfNeeded(QWidget* parentWidget);
+
+  /** Show the crash reporting settings, letting the user change their mind. */
+  static void showSettingsDialog(QWidget* parentWidget);
 
   /**
    * Deliberately crash the application to verify the crash handler.
@@ -98,6 +111,8 @@ inline bool CrashReporter::consentRequested()
   return false;
 }
 inline void CrashReporter::setConsent(bool) {}
+inline void CrashReporter::promptForConsentIfNeeded(QWidget*) {}
+inline void CrashReporter::showSettingsDialog(QWidget*) {}
 inline void CrashReporter::triggerTestCrash() {}
 
 #endif // AVOGADRO_USE_SENTRY

--- a/avogadro/crashreporter.h
+++ b/avogadro/crashreporter.h
@@ -1,0 +1,107 @@
+/******************************************************************************
+  This source file is part of the Avogadro project.
+  This source code is released under the 3-Clause BSD License, (see "LICENSE").
+******************************************************************************/
+
+#ifndef AVOGADRO_CRASHREPORTER_H
+#define AVOGADRO_CRASHREPORTER_H
+
+#include "avogadroappconfig.h"
+
+namespace Avogadro {
+
+/**
+ * @class CrashReporter crashreporter.h
+ * @brief Optional crash reporting, backed by sentry-native.
+ *
+ * Only the separate Windows diagnostic build enables this. In every other
+ * build each method below is an inline no-op, so callers never need to guard
+ * their calls.
+ *
+ * Nothing is uploaded until the user gives consent. Until then reports are
+ * written to a local database and either sent later, if consent is given, or
+ * discarded.
+ */
+class CrashReporter
+{
+public:
+  /** @return true if crash reporting was compiled in and a DSN is configured */
+  static bool isAvailable();
+
+  /**
+   * Start the crash handler.
+   *
+   * Call this from main() before the QApplication instance is constructed, so
+   * that crashes during Qt platform plugin initialization are also captured.
+   * The organization and application names must already be set, since they
+   * determine where the local crash database is kept.
+   *
+   * Prefer declaring a CrashReporterGuard over calling this directly.
+   */
+  static void initialize();
+
+  /** Flush any pending reports and stop the crash handler. */
+  static void shutdown();
+
+  /** @return true if the user has agreed to upload crash reports */
+  static bool hasConsent();
+
+  /** @return true if the user has already been asked about crash reports */
+  static bool consentRequested();
+
+  /** Record the user's decision and apply it to the running handler. */
+  static void setConsent(bool consentGiven);
+
+  /**
+   * Deliberately crash the application to verify the crash handler.
+   *
+   * This exists only to validate the reporting pipeline end to end, and is
+   * reachable solely through the --crash-test command line option in a build
+   * configured with USE_SENTRY.
+   */
+  static void triggerTestCrash();
+};
+
+/**
+ * @class CrashReporterGuard crashreporter.h
+ * @brief Starts crash reporting on construction and stops it on destruction.
+ *
+ * Declaring one of these in main() keeps the handler running for the whole
+ * lifetime of the process, including the early return paths.
+ */
+class CrashReporterGuard
+{
+public:
+  CrashReporterGuard() { CrashReporter::initialize(); }
+  ~CrashReporterGuard() { CrashReporter::shutdown(); }
+
+  CrashReporterGuard(const CrashReporterGuard& other) = delete;
+  CrashReporterGuard& operator=(const CrashReporterGuard& other) = delete;
+};
+
+#ifndef AVOGADRO_USE_SENTRY
+
+// Builds without crash reporting get no object code at all - crashreporter.cpp
+// is only compiled when USE_SENTRY is on.
+inline bool CrashReporter::isAvailable()
+{
+  return false;
+}
+inline void CrashReporter::initialize() {}
+inline void CrashReporter::shutdown() {}
+inline bool CrashReporter::hasConsent()
+{
+  return false;
+}
+inline bool CrashReporter::consentRequested()
+{
+  return false;
+}
+inline void CrashReporter::setConsent(bool) {}
+inline void CrashReporter::triggerTestCrash() {}
+
+#endif // AVOGADRO_USE_SENTRY
+
+} // end namespace Avogadro
+
+#endif // AVOGADRO_CRASHREPORTER_H

--- a/avogadro/crashreporter.h
+++ b/avogadro/crashreporter.h
@@ -8,6 +8,12 @@
 
 #include "avogadroappconfig.h"
 
+// QStringList is a type alias in Qt 6 rather than a class, so it cannot be
+// forward declared by hand - this is Qt's own header for the purpose. It also
+// declares QString.
+#include <QtCore/qcontainerfwd.h>
+
+class QOpenGLWidget;
 class QWidget;
 
 namespace Avogadro {
@@ -66,6 +72,29 @@ public:
   static void showSettingsDialog(QWidget* parentWidget);
 
   /**
+   * Gather what the crash reporter can learn about this session: the OpenGL
+   * driver in use and which plugins are loaded.
+   *
+   * Call once, after the plugins have loaded and the view exists. The driver
+   * strings are read on the first rendered frame, since there is no context
+   * to query before then. @a glWidget may be null, in which case only the
+   * plugin list is recorded.
+   */
+  static void attachSessionContext(QOpenGLWidget* glWidget);
+
+  /**
+   * Leave a trail of what was happening in the run-up to a crash.
+   *
+   * Pass only non-identifying values: a file format identifier rather than a
+   * file name, a tool name rather than what it was applied to.
+   *
+   * Unlike the rest of this class, guard calls that have to build their
+   * message with isAvailable() - formatting the string is not free, and would
+   * otherwise be paid on every platform to be thrown away.
+   */
+  static void addBreadcrumb(const QString& category, const QString& message);
+
+  /**
    * Deliberately crash the application to verify the crash handler.
    *
    * This exists only to validate the reporting pipeline end to end, and is
@@ -113,6 +142,8 @@ inline bool CrashReporter::consentRequested()
 inline void CrashReporter::setConsent(bool) {}
 inline void CrashReporter::promptForConsentIfNeeded(QWidget*) {}
 inline void CrashReporter::showSettingsDialog(QWidget*) {}
+inline void CrashReporter::attachSessionContext(QOpenGLWidget*) {}
+inline void CrashReporter::addBreadcrumb(const QString&, const QString&) {}
 inline void CrashReporter::triggerTestCrash() {}
 
 #endif // AVOGADRO_USE_SENTRY

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -610,6 +610,7 @@ void MainWindow::setupInterface()
 
   viewActivated(glWidget);
   buildTools();
+  CrashReporter::attachSessionContext(glWidget);
   // Connect to the invalid context signal, check whether GL is initialized.
   // connect(m_glWidget, SIGNAL(rendererInvalid()), SLOT(rendererInvalid()));
   connect(m_multiViewWidget, &QtGui::MultiViewWidget::activeWidgetChanged, this,
@@ -1037,6 +1038,10 @@ bool MainWindow::openFile(const QString& fileName, Io::FileFormat* reader)
     return false;
 
   QString ident = QString::fromStdString(reader->identifier());
+  if (CrashReporter::isAvailable()) {
+    CrashReporter::addBreadcrumb(QStringLiteral("file"),
+                                 QStringLiteral("open format=%1").arg(ident));
+  }
 
   // Prepare the background thread to read in the selected file.
   if (!m_fileReadThread)
@@ -1559,14 +1564,19 @@ void MainWindow::toolActivated()
   if (auto* action = qobject_cast<QAction*>(sender())) {
     if (auto* glWidget =
           qobject_cast<GLWidget*>(m_multiViewWidget->activeWidget())) {
-      glWidget->setActiveTool(action->data().toString());
+      const QString toolId = action->data().toString();
+      glWidget->setActiveTool(toolId);
+      if (CrashReporter::isAvailable()) {
+        CrashReporter::addBreadcrumb(
+          QStringLiteral("tool"), QStringLiteral("activated %1").arg(toolId));
+      }
       if (glWidget->activeTool()) {
         m_toolDock->setWidget(glWidget->activeTool()->toolWidget());
         m_toolDock->setWindowTitle(action->text());
 
         // uncheck the toolbar
         foreach (QAction* barAction, m_toolToolBar->actions()) {
-          if (action->data().toString() != barAction->data().toString())
+          if (toolId != barAction->data().toString())
             barAction->setChecked(false);
         }
       }

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -8,6 +8,7 @@
 #include "aboutdialog.h"
 #include "avogadroappconfig.h"
 #include "backgroundfileformat.h"
+#include "crashreporter.h"
 #include "menubuilder.h"
 #include "renderingdialog.h"
 #include "tdxcontroller.h"
@@ -2706,6 +2707,15 @@ void MainWindow::buildMenu()
   auto* bug = new QAction(tr("&Report a Bug"), this);
   m_menuBuilder->addAction(helpPath, bug, 20);
   connect(bug, &QAction::triggered, this, &MainWindow::openBugReport);
+
+  // Only present on the diagnostic build, which is the only one that has
+  // anything to report.
+  if (CrashReporter::isAvailable()) {
+    auto* crashReporting = new QAction(tr("&Crash Reporting…"), this);
+    m_menuBuilder->addAction(helpPath, crashReporting, 15);
+    connect(crashReporting, &QAction::triggered, this,
+            [this]() { CrashReporter::showSettingsDialog(this); });
+  }
 
   auto* feature = new QAction(tr("&Suggest a Feature"), this);
   m_menuBuilder->addAction(helpPath, feature, 10);

--- a/cmake/COPYING.sentry
+++ b/cmake/COPYING.sentry
@@ -1,0 +1,246 @@
+Crash reporting components bundled with the Avogadro 2 diagnostic build
+=======================================================================
+
+This build ships two additional third-party components, used only for crash
+reporting. They are absent from the standard Avogadro 2 build.
+
+  sentry-native  (sentry.dll)                       MIT License
+  https://github.com/getsentry/sentry-native
+
+  Crashpad       (crashpad_handler.exe,             Apache License 2.0
+                  crashpad_wer.dll)
+  https://chromium.googlesource.com/crashpad/crashpad
+
+Both licences are compatible with Avogadro's own 3-Clause BSD licence, which
+is reproduced in the LICENSE file alongside this one.
+
+
+sentry-native - MIT License
+===========================
+
+Copyright (c) 2019 Sentry (https://sentry.io) and individual contributors.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Crashpad - Apache License 2.0
+=============================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cmake/avogadro2.nsi.in
+++ b/cmake/avogadro2.nsi.in
@@ -6,15 +6,16 @@
 SetCompressor /SOLID lzma
 
 ; Basic Information
-!define APP_NAME "Avogadro2"
+!define APP_NAME "@NSIS_APP_NAME@"
 !define APP_VERSION "@AvogadroApp_VERSION@"
 !define APP_PUBLISHER "Avogadro"
 !define APP_EXE "avogadro2.exe"
 !define INSTALL_DIR "$PROGRAMFILES64\${APP_NAME}"
+@NSIS_FILE_ASSOCIATIONS@
 
 ; General Settings
 Name "${APP_NAME}"
-OutFile "Avogadro2-Setup.exe"
+OutFile "@NSIS_OUTFILE@"
 InstallDir "${INSTALL_DIR}"
 InstallDirRegKey HKLM "Software\${APP_NAME}" "InstallDir"
 RequestExecutionLevel admin
@@ -72,6 +73,9 @@ RequestExecutionLevel admin
 !insertmacro MUI_LANGUAGE "Vietnamese"
 
 
+; File associations are registered only by the release build - see the
+; NSIS_FILE_ASSOCIATIONS comment in avogadro/CMakeLists.txt.
+!ifdef REGISTER_FILE_ASSOCIATIONS
 ; Function to register file associations
 Function RegisterFileAssociation
     ; Parameters: $0 = file extension (e.g., ".xyz")
@@ -90,7 +94,9 @@ Function RegisterFileAssociation
     WriteRegStr HKCR "$1\shell\open" "" "Open with ${APP_NAME}"
     WriteRegStr HKCR "$1\shell\open\command" "" '"$INSTDIR\bin\${APP_EXE}" "%1"'
 FunctionEnd
+!endif
 
+!ifdef REGISTER_FILE_ASSOCIATIONS
 ; Function to unregister file associations
 Function un.UnregisterFileAssociation
     ; Parameter: $0 = file extension
@@ -100,6 +106,7 @@ Function un.UnregisterFileAssociation
     DeleteRegKey HKCR "$1"
     DeleteRegKey HKCR "$0"
 FunctionEnd
+!endif
 
 ; Installer Section
 Section "Install"
@@ -129,6 +136,7 @@ Section "Install"
     ; Create Desktop shortcut
     CreateShortcut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\bin\${APP_EXE}"
 
+!ifdef REGISTER_FILE_ASSOCIATIONS
     ; Register file associations
     Push ".xyz"
     Push "Avogadro2.XYZ"
@@ -174,6 +182,7 @@ Section "Install"
 
     ; Notify Windows of file association changes
     System::Call 'shell32.dll::SHChangeNotify(i, i, i, i) v (0x08000000, 0, 0, 0)'
+!endif
 
     ; Write registry keys for Add/Remove Programs
     WriteRegStr HKLM "Software\${APP_NAME}" "InstallDir" "$INSTDIR"
@@ -189,6 +198,7 @@ SectionEnd
 
 ; Uninstaller Section
 Section "Uninstall"
+!ifdef REGISTER_FILE_ASSOCIATIONS
     ; Unregister file associations
     Push ".xyz"
     Call un.UnregisterFileAssociation
@@ -213,6 +223,7 @@ Section "Uninstall"
 
     ; Notify Windows of file association changes
     System::Call 'shell32.dll::SHChangeNotify(i, i, i, i) v (0x08000000, 0, 0, 0)'
+!endif
 
     ; Remove files and directories
     RMDir /r "$INSTDIR\bin"

--- a/flatpak/org.openchemistry.Avogadro2.yaml
+++ b/flatpak/org.openchemistry.Avogadro2.yaml
@@ -75,7 +75,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/openbabel/openbabel.git
-        commit: 32cf131444c1555c749b356dab44fb9fe275271f
+        commit: 1afe81019b781c857eecb86251e106e2f31da928
 
   - name: avogadro2
     buildsystem: cmake-ninja
@@ -117,13 +117,13 @@ modules:
       # BEGIN GENERATED SOURCES -- edit projects.cmake, then run cmake/flatpak_sources.cmake
       # glew
       - type: file
-        url: https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0.tgz
-        sha256: d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1
+        url: https://github.com/nigels-com/glew/releases/download/glew-2.3.1/glew-2.3.1.tgz
+        sha256: b64790f94b926acd7e8f84c5d6000a86cb43967bd1e688b03089079799c9e889
         dest: Downloads
       # eigen
       - type: file
-        url: https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
-        sha256: 8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72
+        url: https://gitlab.com/libeigen/eigen/-/archive/3.4.1/eigen-3.4.1.tar.gz
+        sha256: b93c667d1b69265cdb4d9f30ec21f8facbbe8b307cf34c0b9942834c6d4fdbe2
         dest: Downloads
       # spglib
       - type: file


### PR DESCRIPTION
Should offer testers a crash-logging trace but not the default

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional crash reporting for Windows diagnostic builds.
  * Added consent management and a **Crash Reporting…** settings option.
  * Added safeguards to remove local home-directory paths from diagnostic data.
  * Added diagnostic crash-test support for verifying crash reporting.
  * Diagnostic builds are clearly identified in the application and installers.

* **Bug Fixes**
  * Builds without crash-reporting support now continue to work with the feature disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->