### PR TITLE
Update with ASAN / LSAN rules from avogadrolibs

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -105,6 +105,8 @@ jobs:
         set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
         set(ENV{ASAN_OPTIONS} "new_delete_type_mismatch=0")
         set(ENV{TSAN_OPTIONS} "suppressions=$ENV{GITHUB_WORKSPACE}/openchemistry/avogadrolibs/.github/tsan-suppressions.txt halt_on_error=0 second_deadlock_stack=1")
+        # ASan runs LSan at exit too, so this covers both sanitizer jobs.
+        set(ENV{LSAN_OPTIONS} "suppressions=$ENV{GITHUB_WORKSPACE}/openchemistry/avogadrolibs/.github/lsan-suppressions.txt print_suppressions=0")
         execute_process(
           COMMAND ctest -j ${N}
           WORKING_DIRECTORY ${{ runner.workspace }}/build/avogadrolibs


### PR DESCRIPTION
Avoids false positives from Qt itself

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
