### PR TITLE
Fix a crash on quit when plugins report being destroyed

### DIFF
--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -455,6 +455,10 @@ MainWindow::MainWindow(const QStringList& fileNames, bool disableSettings,
 
 MainWindow::~MainWindow()
 {
+  // Do this first, while our members are still alive: the views, and the
+  // plugins parented to them, are deleted later by QWidget::~QWidget.
+  disconnectCommandSignals();
+
 #ifdef _3DCONNEXION
   m_TDxController->disableController();
 #endif
@@ -3606,6 +3610,19 @@ void MainWindow::abandonCommand(quint64 token)
       return;
     }
   }
+}
+
+void MainWindow::disconnectCommandSignals()
+{
+  foreach (const QMetaObject::Connection& connection,
+           m_pluginCommandConnections)
+    disconnect(connection);
+
+  m_pluginCommandConnections.clear();
+  // Nothing can report back now, so no token is still owed a reply. The
+  // RPC listener fails any request still waiting when the application
+  // quits, so callers are not left hanging.
+  m_inFlightCommands.clear();
 }
 
 void MainWindow::pluginDestroyed(QObject* plugin)

--- a/avogadro/mainwindow.h
+++ b/avogadro/mainwindow.h
@@ -7,6 +7,7 @@
 #define AVOGADRO_MAINWINDOW_H
 
 #include <QtCore/QHash>
+#include <QtCore/QList>
 #include <QtCore/QStringList>
 #include <QtCore/QVariantMap>
 #include <QtWidgets/QMainWindow>
@@ -493,15 +494,44 @@ private:
   template<typename PluginType>
   void connectCommandSignals(PluginType* plugin)
   {
-    connect(plugin, &PluginType::commandStarted, this,
-            &MainWindow::pluginCommandStarted, Qt::UniqueConnection);
-    connect(plugin, &PluginType::commandFinished, this,
-            &MainWindow::pluginCommandFinished, Qt::UniqueConnection);
-    connect(plugin, &PluginType::commandFailed, this,
-            &MainWindow::pluginCommandFailed, Qt::UniqueConnection);
-    connect(plugin, &QObject::destroyed, this, &MainWindow::pluginDestroyed,
-            Qt::UniqueConnection);
+    // Each connection is remembered so that ~MainWindow can sever it while
+    // this object's members are still alive. See disconnectCommandSignals().
+    rememberConnection(connect(plugin, &PluginType::commandStarted, this,
+                               &MainWindow::pluginCommandStarted,
+                               Qt::UniqueConnection));
+    rememberConnection(connect(plugin, &PluginType::commandFinished, this,
+                               &MainWindow::pluginCommandFinished,
+                               Qt::UniqueConnection));
+    rememberConnection(connect(plugin, &PluginType::commandFailed, this,
+                               &MainWindow::pluginCommandFailed,
+                               Qt::UniqueConnection));
+    rememberConnection(connect(plugin, &QObject::destroyed, this,
+                               &MainWindow::pluginDestroyed,
+                               Qt::UniqueConnection));
   }
+
+  /**
+   * Keep a connection made by connectCommandSignals() so it can be undone.
+   * A repeated Qt::UniqueConnection returns an invalid handle, which is
+   * dropped rather than accumulated.
+   */
+  void rememberConnection(const QMetaObject::Connection& connection)
+  {
+    if (connection)
+      m_pluginCommandConnections.append(connection);
+  }
+
+  /**
+   * Sever every connection made by connectCommandSignals().
+   *
+   * This must happen before ~MainWindow lets its members go. Plugins are
+   * parented to the views, which QWidget::~QWidget deletes *after* our own
+   * members are destroyed but *before* QObject::~QObject would have severed
+   * these connections. Without this, a plugin's destroyed() signal still
+   * reaches pluginDestroyed(), which then reads a destroyed
+   * m_inFlightCommands and the application crashes on quit.
+   */
+  void disconnectCommandSignals();
 
   /** Start tracking the signals a plugin emits while handling a command. */
   void beginPluginCommand(QObject* plugin);
@@ -571,6 +601,8 @@ private:
   QVariantMap m_currentCommandResult;
   // Plugins running a command in the background, and the token to report.
   QHash<QObject*, quint64> m_inFlightCommands;
+  // Connections made by connectCommandSignals(), undone in ~MainWindow.
+  QList<QMetaObject::Connection> m_pluginCommandConnections;
 
   QAction* m_undo;
   QAction* m_redo;


### PR DESCRIPTION
When automating via JSON-RPC, MainWindow connects to each destroyed() signal so that a command can be failed.

In some cases, the signal led to reading freed memory = crash

connectCommandSignals() now remembers each connection it makes, and ~MainWindow severs them all before anything else, while its members are still alive.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
