### PR TITLE
Add RPC introspection commands

### DIFF
--- a/avogadro/avogadro.cpp
+++ b/avogadro/avogadro.cpp
@@ -359,6 +359,7 @@ int main(int argc, char* argv[])
   QStringList fileNames;
   bool disableSettings = false;
   bool skipAutosave = false;
+  QString rpcName = QStringLiteral("avogadro");
 #ifdef QTTESTING
   QString testFile;
   bool testExit = true;
@@ -366,7 +367,9 @@ int main(int argc, char* argv[])
   QStringList args = QCoreApplication::arguments();
   for (QStringList::const_iterator it = args.constBegin() + 1;
        it != args.constEnd(); ++it) {
-    if (*it == "--test-file" && it + 1 != args.constEnd()) {
+    if (*it == "--rpc-name" && it + 1 != args.constEnd()) {
+      rpcName = *(++it);
+    } else if (*it == "--test-file" && it + 1 != args.constEnd()) {
 #ifdef QTTESTING
       testFile = *(++it);
 #else
@@ -413,7 +416,7 @@ int main(int argc, char* argv[])
 
 #ifdef Avogadro_ENABLE_RPC
   // create rpc listener
-  Avogadro::RpcListener listener;
+  Avogadro::RpcListener listener(rpcName);
   listener.start();
 #endif
 

--- a/avogadro/avogadro.cpp
+++ b/avogadro/avogadro.cpp
@@ -122,6 +122,27 @@ void configureOpenGLContext()
 #endif
 }
 
+namespace {
+
+/// Every command line option main() recognizes below. Used so that an option
+/// following a value-taking option (e.g. "--rpc-name --disable-settings") is
+/// not silently swallowed as that option's value. A value that merely starts
+/// with a dash, such as the socket name "-my-socket", is still accepted.
+bool isKnownOption(const QString& argument)
+{
+  static const char* const knownOptions[] = {
+    "--rpc-name",         "--test-file",     "--test-no-exit",
+    "--disable-settings", "--skip-autosave", "--crash-test"
+  };
+  for (const char* option : knownOptions) {
+    if (argument == QLatin1String(option))
+      return true;
+  }
+  return false;
+}
+
+} // namespace
+
 int main(int argc, char* argv[])
 {
 #ifdef Q_OS_MAC
@@ -367,9 +388,17 @@ int main(int argc, char* argv[])
   QStringList args = QCoreApplication::arguments();
   for (QStringList::const_iterator it = args.constBegin() + 1;
        it != args.constEnd(); ++it) {
-    if (*it == "--rpc-name" && it + 1 != args.constEnd()) {
+    if (*it == "--rpc-name") {
+      if (it + 1 == args.constEnd() || isKnownOption(*(it + 1))) {
+        qWarning("Avogadro called with --rpc-name but no socket name.");
+        return EXIT_FAILURE;
+      }
       rpcName = *(++it);
-    } else if (*it == "--test-file" && it + 1 != args.constEnd()) {
+    } else if (*it == "--test-file") {
+      if (it + 1 == args.constEnd() || isKnownOption(*(it + 1))) {
+        qWarning("Avogadro called with --test-file but no file name.");
+        return EXIT_FAILURE;
+      }
 #ifdef QTTESTING
       testFile = *(++it);
 #else

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -2126,9 +2126,10 @@ QtOpenGL::GLWidget* MainWindow::activeGLWidget() const
   return qobject_cast<GLWidget*>(m_multiViewWidget->activeWidget());
 }
 
-QImage MainWindow::renderToImage(const QSize& size, bool transparentBackground)
+QImage MainWindow::renderToImage(const QSize& requestedSize,
+                                 bool transparentBackground, QSize* nativeSize)
 {
-  QImage exportImage(size, QImage::Format_ARGB32);
+  QImage exportImage;
 
   auto* glWidget =
     qobject_cast<QOpenGLWidget*>(m_multiViewWidget->activeWidget());
@@ -2170,13 +2171,53 @@ QImage MainWindow::renderToImage(const QSize& size, bool transparentBackground)
   scene->setBackgroundColor(cColor);
   glWidget->repaint();
 
-  if (!transparentBackground) {
-    // Composite the transparent render over the view's actual background
-    // colour, so the caller gets an opaque image.
+  if (nativeSize != nullptr)
+    *nativeSize = exportImage.size();
+
+  if (requestedSize.isValid() && !requestedSize.isEmpty()) {
+    // Fit the native grab onto a canvas of exactly requestedSize: scale
+    // preserving aspect ratio, then centre it, filling any letterboxing
+    // with either the view's background colour or transparency. This also
+    // serves as the "!transparentBackground" composite for this path, so
+    // that block must not run again below.
+    //
+    // Note: padding to a different aspect ratio preserves the original
+    // framing rather than re-composing the scene, so a render padded to an
+    // aspect ratio it wasn't composed for will sit smaller in frame than a
+    // true render at that aspect would. This is a deliberate stopgap until
+    // a real offscreen framebuffer render path replaces the
+    // grab-and-resample approach here.
+    QImage fitted(requestedSize, QImage::Format_ARGB32_Premultiplied);
+    fitted.fill(transparentBackground ? QColor(Qt::transparent)
+                                      : QColor(red, green, blue, 255));
+    QImage scaled = exportImage.scaled(requestedSize, Qt::KeepAspectRatio,
+                                       Qt::SmoothTransformation);
+    // QImage::scaled() propagates the source's device pixel ratio (2 on a
+    // Retina grab). QPainter::drawImage() honours that ratio and draws at
+    // logical size, so without resetting it here the content lands scaled
+    // down into a corner of "fitted" instead of filling it. "fitted" itself
+    // is already ratio-1.0 (default-constructed), and requestedSize/painter
+    // coordinates below are in raw pixels, so the drawn image must match.
+    scaled.setDevicePixelRatio(1.0);
+    QPainter painter(&fitted);
+    painter.drawImage((requestedSize.width() - scaled.width()) / 2,
+                      (requestedSize.height() - scaled.height()) / 2, scaled);
+    painter.end();
+    exportImage = fitted.convertToFormat(QImage::Format_ARGB32);
+  } else if (!transparentBackground) {
+    // No resize requested: composite the transparent render over the
+    // view's actual background colour, so the caller gets an opaque image.
     QImage opaqueImage(exportImage.size(), QImage::Format_ARGB32_Premultiplied);
     opaqueImage.fill(QColor(red, green, blue, 255));
+    // Draw a ratio-1.0 copy of the source: opaqueImage was constructed with
+    // exportImage.size() (raw pixels) at the default ratio of 1.0, but a
+    // Retina grabFramebuffer() image carries devicePixelRatio() == 2.
+    // QPainter::drawImage() honours the source ratio and would draw it at
+    // half size into the top-left quadrant otherwise.
+    QImage source = exportImage;
+    source.setDevicePixelRatio(1.0);
     QPainter painter(&opaqueImage);
-    painter.drawImage(0, 0, exportImage);
+    painter.drawImage(0, 0, source);
     painter.end();
     exportImage = opaqueImage.convertToFormat(QImage::Format_ARGB32);
   }
@@ -2225,8 +2266,10 @@ void MainWindow::exportGraphics(QString fileName)
   if (QFileInfo(fileName).suffix().isEmpty())
     fileName += ".png";
 
-  const QSize size = m_multiViewWidget->activeWidget()->size();
-  QImage exportImage = renderToImage(size);
+  // Pass no size, so we get the untouched native framebuffer grab (full
+  // device resolution), not a copy resampled down to the logical widget
+  // size.
+  QImage exportImage = renderToImage();
 
   if (!exportImage.save(fileName)) {
     QMessageBox::warning(this, tr("Avogadro"),
@@ -2236,7 +2279,10 @@ void MainWindow::exportGraphics(QString fileName)
 
 void MainWindow::copyGraphics()
 {
-  QImage exportImage = renderToImage(m_multiViewWidget->activeWidget()->size());
+  // Pass no size, so we get the untouched native framebuffer grab (full
+  // device resolution), not a copy resampled down to the logical widget
+  // size.
+  QImage exportImage = renderToImage();
   QApplication::clipboard()->setImage(exportImage);
 }
 

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -66,6 +66,7 @@
 #include <QtGui/QDesktopServices>
 #include <QtGui/QKeyEvent>
 #include <QtGui/QKeySequence>
+#include <QtGui/QPainter>
 #include <QtGui/QPalette>
 #include <QtGui/QShortcut>
 
@@ -1279,6 +1280,7 @@ bool MainWindow::backgroundWriterFinished()
 {
   QString fileName = m_threadedWriter->fileName();
   bool success = false;
+  QString errorMessage;
   if (!m_progressDialog->wasCanceled()) {
     if (m_threadedWriter->success()) {
       statusBar()->showMessage(
@@ -1290,12 +1292,15 @@ bool MainWindow::backgroundWriterFinished()
       updateRecentFiles();
       success = true;
     } else {
+      errorMessage = m_threadedWriter->error();
       QMessageBox::critical(
         this, tr("Error saving file"),
         tr("Error while saving '%1':\n%2", "%1 = file name, %2 = error message")
           .arg(fileName)
-          .arg(m_threadedWriter->error()));
+          .arg(errorMessage));
     }
+  } else {
+    errorMessage = tr("The save was canceled.");
   }
   m_fileWriteThread->deleteLater();
   m_fileWriteThread = nullptr;
@@ -1307,6 +1312,16 @@ bool MainWindow::backgroundWriterFinished()
   // On successful save, remove any autosave files
   if (success)
     cleanupAutosaves(fileName);
+
+  // Report back to a script that is waiting on this export via RPC, the
+  // same way a plugin command does.
+  if (m_pendingExportToken != 0) {
+    const quint64 token = m_pendingExportToken;
+    m_pendingExportToken = 0;
+    QVariantMap result;
+    result["fileName"] = fileName;
+    emit commandCompleted(token, success, errorMessage, result);
+  }
 
   return success;
 }
@@ -2100,7 +2115,18 @@ void MainWindow::viewActivated(QWidget* widget)
   activeMoleculeEdited();
 }
 
-QImage MainWindow::renderToImage(const QSize& size)
+QSize MainWindow::activeViewSize() const
+{
+  QWidget* widget = m_multiViewWidget->activeWidget();
+  return widget != nullptr ? widget->size() : QSize();
+}
+
+QtOpenGL::GLWidget* MainWindow::activeGLWidget() const
+{
+  return qobject_cast<GLWidget*>(m_multiViewWidget->activeWidget());
+}
+
+QImage MainWindow::renderToImage(const QSize& size, bool transparentBackground)
 {
   QImage exportImage(size, QImage::Format_ARGB32);
 
@@ -2143,6 +2169,17 @@ QImage MainWindow::renderToImage(const QSize& size)
   cColor[3] = alpha; // previous color
   scene->setBackgroundColor(cColor);
   glWidget->repaint();
+
+  if (!transparentBackground) {
+    // Composite the transparent render over the view's actual background
+    // colour, so the caller gets an opaque image.
+    QImage opaqueImage(exportImage.size(), QImage::Format_ARGB32_Premultiplied);
+    opaqueImage.fill(QColor(red, green, blue, 255));
+    QPainter painter(&opaqueImage);
+    painter.drawImage(0, 0, exportImage);
+    painter.end();
+    exportImage = opaqueImage.convertToFormat(QImage::Format_ARGB32);
+  }
 
   // Now we embed molecular information into the file, if possible
   if (m_molecule && m_molecule->atomCount() < 1000) {
@@ -2397,7 +2434,7 @@ bool MainWindow::exportFile(bool async)
   return saveFileAs(reply.second, reply.first->newInstance(), async);
 }
 
-bool MainWindow::exportFile(const QString& fileName, bool async)
+bool MainWindow::exportFile(const QString& fileName, bool async, quint64 token)
 {
   if (fileName.isEmpty()) {
     return false;
@@ -2413,6 +2450,11 @@ bool MainWindow::exportFile(const QString& fileName, bool async)
 
   if (!writers.empty()) {
     writer = writers[0]->newInstance();
+    // Remember the token so backgroundWriterFinished() can report back once
+    // the write completes, the same way a plugin command does. Only takes
+    // effect for an async write; harmless otherwise since it is cleared
+    // there before it could be read again.
+    m_pendingExportToken = token;
     return saveFileAs(fileName, writer, async);
   }
 
@@ -3512,6 +3554,33 @@ void MainWindow::registerExtensionCommand(QString command, QString description)
     return;
 
   m_extensionCommandMap.insert(command, extension);
+}
+
+QVariantList MainWindow::pluginCommands() const
+{
+  QVariantList commands;
+
+  for (auto it = m_toolCommandMap.constBegin();
+       it != m_toolCommandMap.constEnd(); ++it) {
+    QVariantMap entry;
+    entry["name"] = it.key();
+    entry["description"] = m_commandDescriptionsMap.value(it.key());
+    entry["kind"] = QStringLiteral("tool");
+    entry["plugin"] = it.value();
+    commands.append(entry);
+  }
+
+  for (auto it = m_extensionCommandMap.constBegin();
+       it != m_extensionCommandMap.constEnd(); ++it) {
+    QVariantMap entry;
+    entry["name"] = it.key();
+    entry["description"] = m_commandDescriptionsMap.value(it.key());
+    entry["kind"] = QStringLiteral("extension");
+    entry["plugin"] = it.value() != nullptr ? it.value()->name() : QString();
+    commands.append(entry);
+  }
+
+  return commands;
 }
 
 void MainWindow::beginPluginCommand(QObject* plugin)

--- a/avogadro/mainwindow.cpp
+++ b/avogadro/mainwindow.cpp
@@ -2141,6 +2141,12 @@ QImage MainWindow::renderToImage(const QSize& requestedSize,
          qobject_cast<GLWidget*>(m_multiViewWidget->activeWidget()))) {
     scene = &viewWidget->renderer().scene();
   }
+
+  // Without an active GL view there is nothing to grab; hand back a null
+  // image so callers can report the failure rather than crash here.
+  if (scene == nullptr || glWidget == nullptr)
+    return QImage();
+
   Vector4ub cColor = scene->backgroundColor();
   unsigned char red = cColor[0];
   unsigned char green = cColor[1];
@@ -2486,6 +2492,14 @@ bool MainWindow::exportFile(const QString& fileName, bool async, quint64 token)
     return false;
   }
 
+  // A background write is already in flight. Its completion token would be
+  // overwritten below, so refuse the request rather than misreport which
+  // export finished. Checked here as well as in saveFileAs() so the token is
+  // never clobbered before that check runs.
+  if (m_fileWriteThread != nullptr) {
+    return false;
+  }
+
   // Create one of our writers to save the file:
   FileFormat* writer = nullptr;
 
@@ -2528,25 +2542,29 @@ bool MainWindow::saveFileAs(const QString& fileName, Io::FileFormat* writer,
   QString ident = QString::fromStdString(writer->identifier());
 
   // Figure out what molecule willl be saved, perform conversion if necessary.
-  QObject* molObj = m_moleculeModel->activeMolecule();
+  // Resolved before anything is allocated below: BackgroundFileFormat takes
+  // ownership of the writer, so bailing out after it is constructed would
+  // both double delete the writer and leave the write state half set up.
+  auto* mol = qobject_cast<Molecule*>(m_moleculeModel->activeMolecule());
 
-  if (!molObj) {
+  if (!mol) {
+    delete writer;
+    return false;
+  }
+
+  // Only one write can be in flight: m_threadedWriter, m_progressDialog and
+  // m_pendingExportToken are all single-slot state, so starting a second one
+  // now would strand the running thread and report its result against the
+  // wrong request. backgroundWriterFinished() clears the thread when it is
+  // done, so this only rejects genuinely concurrent writes.
+  if (m_fileWriteThread != nullptr) {
     delete writer;
     return false;
   }
 
   // Initialize out writer.
-  if (!m_fileWriteThread)
-    m_fileWriteThread = new QThread(this);
-  if (m_threadedWriter)
-    m_threadedWriter->deleteLater();
+  m_fileWriteThread = new QThread(this);
   m_threadedWriter = new BackgroundFileFormat(writer);
-
-  auto* mol = qobject_cast<Molecule*>(molObj);
-  if (!mol) {
-    delete writer;
-    return false;
-  }
 
   // get the camera modelView and projection to save it
   if (auto* glWidget =
@@ -3613,6 +3631,9 @@ QVariantList MainWindow::pluginCommands() const
     entry["description"] = m_commandDescriptionsMap.value(it.key());
     entry["kind"] = QStringLiteral("tool");
     entry["plugin"] = it.value();
+    // Any plugin command may report itself as started and finish later, so
+    // a caller has to be ready for a deferred reply from all of them.
+    entry["async"] = true;
     commands.append(entry);
   }
 
@@ -3623,6 +3644,7 @@ QVariantList MainWindow::pluginCommands() const
     entry["description"] = m_commandDescriptionsMap.value(it.key());
     entry["kind"] = QStringLiteral("extension");
     entry["plugin"] = it.value() != nullptr ? it.value()->name() : QString();
+    entry["async"] = true;
     commands.append(entry);
   }
 

--- a/avogadro/mainwindow.h
+++ b/avogadro/mainwindow.h
@@ -234,13 +234,21 @@ public:
   QtOpenGL::GLWidget* activeGLWidget() const;
 
   /**
-   * Render the active view to an image of the requested size.
-   * @param size The image size, in pixels.
+   * Render the active view to an image.
+   * @param requestedSize The desired output size, in pixels. If null or
+   * empty (the default), the native framebuffer grab is returned untouched,
+   * at whatever resolution the view actually rendered (i.e. widget size
+   * times device pixel ratio). Otherwise the native grab is scaled with
+   * Qt::KeepAspectRatio and centred on a canvas of exactly this size.
    * @param transparentBackground If true (the default, matching prior
    * behaviour) the background is left transparent; otherwise the image is
    * composited over the view's current background colour.
+   * @param nativeSize If non-null, receives the native grab's actual
+   * dimensions (before any scaling to requestedSize was applied).
    */
-  QImage renderToImage(const QSize& size, bool transparentBackground = true);
+  QImage renderToImage(const QSize& requestedSize = QSize(),
+                       bool transparentBackground = true,
+                       QSize* nativeSize = nullptr);
 
 signals:
   /**

--- a/avogadro/mainwindow.h
+++ b/avogadro/mainwindow.h
@@ -106,12 +106,17 @@ public slots:
    * Export a file, using the full selection of formats capable of writing.
    * The format will be guessed based on the filename extension.
    * If @a async is true (default), the file is saved asynchronously.
+   * @param token When @a async is true and non-zero, commandCompleted() is
+   * emitted with this token once the background write finishes, the same
+   * way a plugin command reports back. Used by the RPC listener's "wait"
+   * support; ignored otherwise.
    * @return If @a async is true, this function returns true if a suitable
    * writer was found (not if the write was successful). If @a async is
    * false, the return value indicates whether or not the file was written
    * successfully.
    */
-  bool exportFile(const QString& fileName, bool async = true);
+  bool exportFile(const QString& fileName, bool async = true,
+                  quint64 token = 0);
 
   /**
    * Export a file, using the full selection of formats capable of writing.
@@ -205,6 +210,37 @@ public:
    * reports back does not stay busy for the life of the session.
    */
   void abandonCommand(quint64 token);
+
+  /**
+   * The commands registered by tools and extensions, for RPC introspection
+   * (the "listCommands" method). Built-in commands answered directly by the
+   * RPC listener are not included; it has its own static table for those.
+   *
+   * Each entry is a map with "name", "description", "kind" ("tool" or
+   * "extension") and "plugin" (the owning plugin's display name).
+   */
+  QVariantList pluginCommands() const;
+
+  /**
+   * The size, in pixels, of the currently active view. An empty size if
+   * there is no active view.
+   */
+  QSize activeViewSize() const;
+
+  /**
+   * The active view, if it is an OpenGL widget. Returns nullptr for a
+   * non-GL view (e.g. a VTK crystal view) or when there is no active view.
+   */
+  QtOpenGL::GLWidget* activeGLWidget() const;
+
+  /**
+   * Render the active view to an image of the requested size.
+   * @param size The image size, in pixels.
+   * @param transparentBackground If true (the default, matching prior
+   * behaviour) the background is left transparent; otherwise the image is
+   * composited over the view's current background colour.
+   */
+  QImage renderToImage(const QSize& size, bool transparentBackground = true);
 
 signals:
   /**
@@ -469,8 +505,6 @@ private slots:
    */
   void viewActivated(QWidget* widget);
 
-  QImage renderToImage(const QSize& size);
-
   void exportGraphics();
 
   void copyGraphics();
@@ -537,6 +571,9 @@ private:
   BackgroundFileFormat* m_threadedWriter;
   QProgressDialog* m_progressDialog;
   QtGui::Molecule* m_fileReadMolecule;
+  // Set by exportFile() when the RPC listener is waiting on an async write;
+  // backgroundWriterFinished() reports back through commandCompleted().
+  quint64 m_pendingExportToken = 0;
 
   QToolBar* m_fileToolBar;
   QToolBar* m_toolToolBar;

--- a/avogadro/rpclistener.cpp
+++ b/avogadro/rpclistener.cpp
@@ -19,6 +19,7 @@
 #include <avogadro/qtgui/sceneplugin.h>
 #include <avogadro/qtgui/scenepluginmodel.h>
 #include <avogadro/qtopengl/glwidget.h>
+#include <avogadro/rendering/camera.h>
 
 #include <QtCore/QBuffer>
 #include <QtCore/QByteArray>
@@ -41,6 +42,8 @@ using Io::FileFormatManager;
 using QtGui::Molecule;
 using QtGui::ScenePlugin;
 using QtOpenGL::GLWidget;
+using Rendering::Camera;
+using Rendering::Projection;
 using std::string;
 
 namespace {
@@ -77,6 +80,8 @@ const BuiltinCommand builtinCommands[] = {
   { "exportFile",
     "Write the active molecule to a file, guessing the format from the "
     "extension." },
+  { "getCamera", "Report the active view's camera: distance to focus, "
+                 "focus point, projection and the model view matrix." },
   { "getMolecule", "Return the active molecule serialized as a string." },
   { "internalPing", "Check whether the server is responsive." },
   { "kill", "Shut down Avogadro. Only enabled when started with "
@@ -94,12 +99,56 @@ const BuiltinCommand builtinCommands[] = {
                    "render onto a canvas of exactly that size." },
   { "saveGraphic", "Render the current view and save it as an image at "
                    "the window's current size." },
+  { "setCamera", "Apply a model view matrix and/or projection settings to "
+                 "the active view's camera." },
   { "setProjection",
     "Switch between perspective and orthographic projection." },
   { "setRenderTypes", "Enable or disable scene display types by name." },
   { "version",
     "Report Avogadro application, library, Qt and protocol versions." },
 };
+
+QString projectionToString(Projection projection)
+{
+  return projection == Rendering::Orthographic ? QStringLiteral("orthographic")
+                                               : QStringLiteral("perspective");
+}
+
+Projection projectionFromString(const QString& name)
+{
+  return name == QLatin1String("orthographic") ? Rendering::Orthographic
+                                               : Rendering::Perspective;
+}
+
+/// Flatten the camera's model view matrix into 16 floats in row-major order,
+/// i.e. element [row * 4 + col] is modelView(row, col). This is the order
+/// "setCamera" expects back, and the order every "getCamera" reply uses.
+QVariantList modelViewToVariantList(const Camera& camera)
+{
+  QVariantList result;
+  result.reserve(16);
+  const auto& matrix = camera.modelView().matrix();
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 4; ++col)
+      result.append(static_cast<double>(matrix(row, col)));
+  }
+  return result;
+}
+
+/// Serialize the read-back shape shared by "getCamera" and "setCamera".
+QVariantMap cameraToVariantMap(const Camera& camera)
+{
+  QVariantMap result;
+  result["distance"] = static_cast<double>(camera.distance(camera.focus()));
+  const Vector3f focus = camera.focus();
+  result["focus"] = QVariantList{ static_cast<double>(focus.x()),
+                                  static_cast<double>(focus.y()),
+                                  static_cast<double>(focus.z()) };
+  result["projection"] = projectionToString(camera.projectionType());
+  result["orthographicScale"] = static_cast<double>(camera.orthographicScale());
+  result["modelView"] = modelViewToVariantList(camera);
+  return result;
+}
 } // namespace
 
 RpcListener::RpcListener(const QString& connectionName, QObject* parent_)
@@ -555,6 +604,60 @@ void RpcListener::messageReceived(const RPC::Message& message)
 
     RPC::Message response = message.generateResponse();
     response.setResult(QJsonArray::fromVariantList(types));
+    response.send();
+  } else if (method == "getCamera") {
+    // Read-back: payload goes straight in "result", like "listDisplayTypes".
+    GLWidget* glWidget = m_window->activeGLWidget();
+    if (glWidget == nullptr) {
+      sendError(message, errorRequestFailed, tr("No active view."));
+      return;
+    }
+
+    RPC::Message response = message.generateResponse();
+    response.setResult(QJsonObject::fromVariantMap(
+      cameraToVariantMap(glWidget->renderer().camera())));
+    response.send();
+  } else if (method == "setCamera") {
+    GLWidget* glWidget = m_window->activeGLWidget();
+    if (glWidget == nullptr) {
+      sendError(message, errorRequestFailed, tr("No active view."));
+      return;
+    }
+
+    Camera& camera = glWidget->renderer().camera();
+
+    if (params.contains("modelView")) {
+      const QJsonArray values = params["modelView"].toArray();
+      if (values.size() != 16) {
+        sendError(message, errorRequestFailed,
+                  tr("setCamera's modelView must be exactly 16 numbers, in "
+                     "row-major order."));
+        return;
+      }
+      Eigen::Matrix4f matrix;
+      for (int row = 0; row < 4; ++row) {
+        for (int col = 0; col < 4; ++col)
+          matrix(row, col) =
+            static_cast<float>(values.at(row * 4 + col).toDouble());
+      }
+      Eigen::Affine3f transform;
+      transform.matrix() = matrix;
+      camera.setModelView(transform);
+    }
+
+    if (params.contains("projection"))
+      camera.setProjectionType(
+        projectionFromString(params["projection"].toString()));
+
+    if (params.contains("orthographicScale")) {
+      camera.setOrthographicScale(
+        static_cast<float>(params["orthographicScale"].toDouble()));
+    }
+
+    glWidget->requestUpdate();
+
+    RPC::Message response = message.generateResponse();
+    response.setResult(QJsonObject::fromVariantMap(cameraToVariantMap(camera)));
     response.send();
   } else { // ask the main window to handle the message
     QVariantMap options = params.toVariantMap();

--- a/avogadro/rpclistener.cpp
+++ b/avogadro/rpclistener.cpp
@@ -4,27 +4,43 @@
 ******************************************************************************/
 
 #include "rpclistener.h"
+#include "avogadroappconfig.h"
 #include "mainwindow.h"
-
-#include <QtWidgets/QApplication>
-#include <QtWidgets/QInputDialog>
-
-#include <QtCore/QJsonValue>
-#include <QtCore/QTimer>
-#include <QtCore/QVariantMap>
-
-#include <avogadro/io/fileformatmanager.h>
-#include <avogadro/qtgui/molecule.h>
 
 #include "rpc/connection.h"
 #include "rpc/jsonrpc.h"
 #include "rpc/jsonrpcclient.h"
 #include "rpc/localsocketconnectionlistener.h"
 
+#include <avogadro/core/basisset.h>
+#include <avogadro/core/version.h>
+#include <avogadro/io/fileformatmanager.h>
+#include <avogadro/qtgui/molecule.h>
+#include <avogadro/qtgui/sceneplugin.h>
+#include <avogadro/qtgui/scenepluginmodel.h>
+#include <avogadro/qtopengl/glwidget.h>
+
+#include <QtCore/QBuffer>
+#include <QtCore/QByteArray>
+#include <QtCore/QFileInfo>
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonValue>
+#include <QtCore/QSize>
+#include <QtCore/QTimer>
+#include <QtCore/QVariantMap>
+#include <QtGui/QImage>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QInputDialog>
+
+#include <algorithm>
+
 namespace Avogadro {
 
+using Core::BasisSet;
 using Io::FileFormatManager;
 using QtGui::Molecule;
+using QtGui::ScenePlugin;
+using QtOpenGL::GLWidget;
 using std::string;
 
 namespace {
@@ -40,16 +56,58 @@ constexpr int errorCommandFailed = -2;
 constexpr int errorPluginBusy = -3;
 /// No tool or extension claims this method.
 constexpr int errorMethodNotFound = -32601;
+
+/// The RPC protocol version reported by "version". Bumped whenever the wire
+/// contract changes; "1" was the immediate-reply era and is never reported
+/// by a build that has this command.
+constexpr int rpcProtocolVersion = 2;
+
+/// A single row of the "listCommands" table for a built-in method.
+struct BuiltinCommand
+{
+  const char* name;
+  const char* description;
+};
+
+/// Every method this listener answers itself, i.e. everything handled below
+/// in messageReceived() plus "internalPing" (answered earlier, in JsonRpc)
+/// and "kill". Kept sorted by name for readability; listCommands() sorts its
+/// output anyway.
+const BuiltinCommand builtinCommands[] = {
+  { "exportFile",
+    "Write the active molecule to a file, guessing the format from the "
+    "extension." },
+  { "getMolecule", "Return the active molecule serialized as a string." },
+  { "internalPing", "Check whether the server is responsive." },
+  { "kill", "Shut down Avogadro. Only enabled when started with "
+            "--testing." },
+  { "listCommands", "List every command the server understands." },
+  { "listDisplayTypes",
+    "List the scene display types available for the active view." },
+  { "loadMolecule", "Read molecule data from a string and make it the "
+                    "active molecule." },
+  { "moleculeInfo", "Report summary statistics about the active molecule." },
+  { "openFile", "Read a file from disk and make it the active molecule." },
+  { "renderImage", "Render the current view to a PNG, inline or to a "
+                   "file." },
+  { "saveGraphic", "Render the current view and save it as an image at "
+                   "the window's current size." },
+  { "setProjection",
+    "Switch between perspective and orthographic projection." },
+  { "setRenderTypes", "Enable or disable scene display types by name." },
+  { "version",
+    "Report Avogadro application, library, Qt and protocol versions." },
+};
 } // namespace
 
-RpcListener::RpcListener(QObject* parent_)
+RpcListener::RpcListener(const QString& connectionName, QObject* parent_)
   : QObject(parent_)
   , m_pingClient(nullptr)
 {
   m_rpc = new RPC::JsonRpc(this);
 
   m_connectionListener =
-    new RPC::LocalSocketConnectionListener(this, "avogadro");
+    new RPC::LocalSocketConnectionListener(this, connectionName);
 
   connect(m_connectionListener, &RPC::ConnectionListener::connectionError, this,
           &RpcListener::connectionError);
@@ -176,6 +234,32 @@ void RpcListener::messageReceived(const RPC::Message& message)
     return;
   }
 
+  // Also answered before the window check, next to "kill": a client needs
+  // to be able to negotiate compatibility while Avogadro is still starting.
+  if (method == "version") {
+    QVariantMap result;
+    result["avogadroApp"] = QLatin1String(AvogadroApp_VERSION);
+    result["avogadroLibs"] = QLatin1String(Avogadro::version());
+    result["qt"] = QLatin1String(qVersion());
+#if defined(Q_OS_MAC)
+    result["platform"] = QStringLiteral("macos");
+#elif defined(Q_OS_WIN)
+    result["platform"] = QStringLiteral("windows");
+#elif defined(Q_OS_LINUX)
+    result["platform"] = QStringLiteral("linux");
+#elif defined(Q_OS_BSD4)
+    result["platform"] = QStringLiteral("bsd");
+#else
+    result["platform"] = QStringLiteral("unknown");
+#endif
+    result["rpcProtocol"] = rpcProtocolVersion;
+
+    RPC::Message response = message.generateResponse();
+    response.setResult(QJsonObject::fromVariantMap(result));
+    response.send();
+    return;
+  }
+
   // check if there's an active window
   if (m_window == nullptr) {
     // send error response
@@ -225,12 +309,25 @@ void RpcListener::messageReceived(const RPC::Message& message)
     // Save to the supplied file name
     QString filename = params["fileName"].toString();
 
-    bool result = m_window->exportFile(filename);
+    if (wait) {
+      // Hold the reply until the background write finishes, the same way a
+      // waited plugin command does.
+      const quint64 token = ++m_nextToken;
+      bool started = m_window->exportFile(filename, true, token);
+      if (started) {
+        holdReply(message, token, timeoutSeconds);
+      } else {
+        sendError(message, errorRequestFailed,
+                  QString("Could not start exporting to %1.").arg(filename));
+      }
+    } else {
+      bool result = m_window->exportFile(filename);
 
-    // set response
-    RPC::Message response = message.generateResponse();
-    response.setResult(result);
-    response.send();
+      // set response
+      RPC::Message response = message.generateResponse();
+      response.setResult(result);
+      response.send();
+    }
   } else if (method == "loadMolecule") {
     // get molecule data and format
     string content = params["content"].toString().toStdString();
@@ -258,6 +355,187 @@ void RpcListener::messageReceived(const RPC::Message& message)
           .arg(QString::fromStdString(FileFormatManager::instance().error())));
       errorMessage.send();
     }
+  } else if (method == "listCommands") {
+    // Builtins come from the static table above; tool and extension
+    // commands come from the main window's command maps. Read-backs answer
+    // their payload directly as "result", not wrapped in the usual
+    // "status"/"data" envelope.
+    QVariantList commands;
+    for (const auto& builtin : builtinCommands) {
+      QVariantMap entry;
+      entry["name"] = QLatin1String(builtin.name);
+      entry["description"] = QLatin1String(builtin.description);
+      entry["kind"] = QStringLiteral("builtin");
+      entry["plugin"] = QString();
+      entry["async"] = false;
+      entry["schema"] = QVariantMap();
+      commands.append(entry);
+    }
+    const QVariantList pluginCommands = m_window->pluginCommands();
+    for (const QVariant& item : pluginCommands) {
+      QVariantMap entry = item.toMap();
+      entry["async"] = false;
+      entry["schema"] = QVariantMap();
+      commands.append(entry);
+    }
+    std::sort(commands.begin(), commands.end(),
+              [](const QVariant& a, const QVariant& b) {
+                return a.toMap().value("name").toString() <
+                       b.toMap().value("name").toString();
+              });
+
+    RPC::Message response = message.generateResponse();
+    response.setResult(QJsonArray::fromVariantList(commands));
+    response.send();
+  } else if (method == "moleculeInfo") {
+    QVariantMap info;
+    auto* mol = m_window->molecule();
+
+    info["atomCount"] =
+      mol != nullptr ? static_cast<qulonglong>(mol->atomCount()) : 0;
+    info["bondCount"] =
+      mol != nullptr ? static_cast<qulonglong>(mol->bondCount()) : 0;
+    info["formula"] =
+      mol != nullptr ? QString::fromStdString(mol->formula()) : QString();
+    info["mass"] = mol != nullptr ? mol->mass() : 0.0;
+    info["totalCharge"] =
+      mol != nullptr ? static_cast<int>(mol->totalCharge()) : 0;
+    info["spinMultiplicity"] =
+      mol != nullptr ? static_cast<int>(mol->totalSpinMultiplicity()) : 0;
+    info["coordinateSetCount"] =
+      mol != nullptr ? static_cast<qulonglong>(mol->coordinate3dCount()) : 0;
+
+    size_t selectedAtomCount = 0;
+    if (mol != nullptr) {
+      for (Index i = 0; i < mol->atomCount(); ++i) {
+        if (mol->atomSelected(i))
+          ++selectedAtomCount;
+      }
+    }
+    info["selectedAtomCount"] = static_cast<qulonglong>(selectedAtomCount);
+
+    const Index residueCount = mol != nullptr ? mol->residueCount() : 0;
+    info["residueCount"] = static_cast<qulonglong>(residueCount);
+    info["hasResidues"] = residueCount > 0;
+    info["hasUnitCell"] = mol != nullptr && mol->unitCell() != nullptr;
+    info["hasCustomElements"] = mol != nullptr && mol->hasCustomElements();
+
+    const BasisSet* basis = mol != nullptr ? mol->basisSet() : nullptr;
+    info["hasBasisSet"] = basis != nullptr;
+    info["orbitalCount"] =
+      basis != nullptr ? static_cast<int>(basis->molecularOrbitalCount()) : 0;
+    info["homoIndex"] = basis != nullptr ? static_cast<int>(basis->homo()) : -1;
+
+    info["cubeCount"] =
+      mol != nullptr ? static_cast<qulonglong>(mol->cubeCount()) : 0;
+    info["vibrationCount"] =
+      mol != nullptr
+        ? static_cast<qulonglong>(mol->vibrationFrequencies().size())
+        : 0;
+    info["fileName"] =
+      mol != nullptr ? QString::fromStdString(mol->data("fileName").toString())
+                     : QString();
+
+    RPC::Message response = message.generateResponse();
+    response.setResult(QJsonObject::fromVariantMap(info));
+    response.send();
+  } else if (method == "getMolecule") {
+    QString format = params.contains("format") ? params["format"].toString()
+                                               : QStringLiteral("cjson");
+    if (format.isEmpty())
+      format = QStringLiteral("cjson");
+
+    auto* mol = m_window->molecule();
+    if (mol == nullptr) {
+      sendError(message, errorRequestFailed, tr("No molecule is open."));
+    } else {
+      string content;
+      bool ok = FileFormatManager::instance().writeString(*mol, content,
+                                                          format.toStdString());
+      if (ok) {
+        QVariantMap result;
+        result["format"] = format;
+        result["content"] = QString::fromStdString(content);
+
+        RPC::Message response = message.generateResponse();
+        response.setResult(QJsonObject::fromVariantMap(result));
+        response.send();
+      } else {
+        sendError(message, errorRequestFailed,
+                  QString("Failed to write molecule: %1")
+                    .arg(QString::fromStdString(
+                      FileFormatManager::instance().error())));
+      }
+    }
+  } else if (method == "renderImage") {
+    const QSize defaultSize = m_window->activeViewSize();
+    int width = params.contains("width")
+                  ? params["width"].toInt(defaultSize.width())
+                  : defaultSize.width();
+    int height = params.contains("height")
+                   ? params["height"].toInt(defaultSize.height())
+                   : defaultSize.height();
+    width = qBound(1, width, 8192);
+    height = qBound(1, height, 8192);
+    const bool transparentBackground =
+      params["transparentBackground"].toBool(false);
+    QString fileName = params["fileName"].toString();
+
+    QImage image =
+      m_window->renderToImage(QSize(width, height), transparentBackground);
+
+    if (!fileName.isEmpty()) {
+      if (QFileInfo(fileName).suffix().isEmpty())
+        fileName += ".png";
+      if (image.save(fileName, "PNG")) {
+        QVariantMap result;
+        result["width"] = width;
+        result["height"] = height;
+        result["fileName"] = fileName;
+
+        RPC::Message response = message.generateResponse();
+        response.setResult(QJsonObject::fromVariantMap(result));
+        response.send();
+      } else {
+        sendError(message, errorRequestFailed,
+                  QString("Could not write image to %1.").arg(fileName));
+      }
+    } else {
+      QByteArray bytes;
+      QBuffer buffer(&bytes);
+      buffer.open(QIODevice::WriteOnly);
+      image.save(&buffer, "PNG");
+
+      QVariantMap result;
+      result["width"] = width;
+      result["height"] = height;
+      result["format"] = QStringLiteral("png");
+      result["data"] = QString::fromLatin1(bytes.toBase64());
+
+      RPC::Message response = message.generateResponse();
+      response.setResult(QJsonObject::fromVariantMap(result));
+      response.send();
+    }
+  } else if (method == "listDisplayTypes") {
+    QVariantList types;
+    if (GLWidget* glWidget = m_window->activeGLWidget()) {
+      const QList<ScenePlugin*> plugins = glWidget->sceneModel().scenePlugins();
+      for (ScenePlugin* plugin : plugins) {
+        if (plugin == nullptr)
+          continue;
+        QVariantMap entry;
+        entry["name"] = plugin->objectName();
+        entry["displayName"] = plugin->name();
+        entry["enabled"] = plugin->isEnabled();
+        entry["applicable"] = plugin->isApplicable();
+        entry["hasSettings"] = plugin->hasSetupWidget();
+        types.append(entry);
+      }
+    }
+
+    RPC::Message response = message.generateResponse();
+    response.setResult(QJsonArray::fromVariantList(types));
+    response.send();
   } else { // ask the main window to handle the message
     QVariantMap options = params.toVariantMap();
     // Only a request that asked to wait needs a token to report back with.

--- a/avogadro/rpclistener.cpp
+++ b/avogadro/rpclistener.cpp
@@ -70,6 +70,10 @@ struct BuiltinCommand
 {
   const char* name;
   const char* description;
+  /// True when the command can outlive the call that starts it, i.e. a
+  /// request that passes "wait" may have its reply held until the work
+  /// finishes. False means the reply is always sent immediately.
+  bool async;
 };
 
 /// Every method this listener answers itself, i.e. everything handled below
@@ -79,33 +83,49 @@ struct BuiltinCommand
 const BuiltinCommand builtinCommands[] = {
   { "exportFile",
     "Write the active molecule to a file, guessing the format from the "
-    "extension." },
-  { "getCamera", "Report the active view's camera: distance to focus, "
-                 "focus point, projection and the model view matrix." },
-  { "getMolecule", "Return the active molecule serialized as a string." },
-  { "internalPing", "Check whether the server is responsive." },
-  { "kill", "Shut down Avogadro. Only enabled when started with "
-            "--testing." },
-  { "listCommands", "List every command the server understands." },
+    "extension.",
+    true },
+  { "getCamera",
+    "Report the active view's camera: distance to focus, "
+    "focus point, projection and the model view matrix.",
+    false },
+  { "getMolecule", "Return the active molecule serialized as a string.",
+    false },
+  { "internalPing", "Check whether the server is responsive.", false },
+  { "kill",
+    "Shut down Avogadro. Only enabled when started with "
+    "--testing.",
+    false },
+  { "listCommands", "List every command the server understands.", false },
   { "listDisplayTypes",
-    "List the scene display types available for the active view." },
-  { "loadMolecule", "Read molecule data from a string and make it the "
-                    "active molecule." },
-  { "moleculeInfo", "Report summary statistics about the active molecule." },
-  { "openFile", "Read a file from disk and make it the active molecule." },
-  { "renderImage", "Render the current view to a PNG, inline or to a "
-                   "file. Omit width/height for the native framebuffer "
-                   "resolution, or supply both together to fit that "
-                   "render onto a canvas of exactly that size." },
-  { "saveGraphic", "Render the current view and save it as an image at "
-                   "the window's current size." },
-  { "setCamera", "Apply a model view matrix and/or projection settings to "
-                 "the active view's camera." },
-  { "setProjection",
-    "Switch between perspective and orthographic projection." },
-  { "setRenderTypes", "Enable or disable scene display types by name." },
+    "List the scene display types available for the active view.", false },
+  { "loadMolecule",
+    "Read molecule data from a string and make it the "
+    "active molecule.",
+    false },
+  { "moleculeInfo", "Report summary statistics about the active molecule.",
+    false },
+  { "openFile", "Read a file from disk and make it the active molecule.",
+    false },
+  { "renderImage",
+    "Render the current view to a PNG, inline or to a "
+    "file. Omit width/height for the native framebuffer "
+    "resolution, or supply both together to fit that "
+    "render onto a canvas of exactly that size.",
+    false },
+  { "saveGraphic",
+    "Render the current view and save it as an image at "
+    "the window's current size.",
+    false },
+  { "setCamera",
+    "Apply a model view matrix and/or projection settings to "
+    "the active view's camera.",
+    false },
+  { "setProjection", "Switch between perspective and orthographic projection.",
+    false },
+  { "setRenderTypes", "Enable or disable scene display types by name.", false },
   { "version",
-    "Report Avogadro application, library, Qt and protocol versions." },
+    "Report Avogadro application, library, Qt and protocol versions.", false },
 };
 
 QString projectionToString(Projection projection)
@@ -418,15 +438,15 @@ void RpcListener::messageReceived(const RPC::Message& message)
       entry["description"] = QLatin1String(builtin.description);
       entry["kind"] = QStringLiteral("builtin");
       entry["plugin"] = QString();
-      entry["async"] = false;
-      entry["schema"] = QVariantMap();
+      entry["async"] = builtin.async;
       commands.append(entry);
     }
+    // Any tool or extension command may report itself as started and finish
+    // later, so they are all flagged as possibly asynchronous; whether a
+    // given call actually defers its reply is only known once it runs.
     const QVariantList pluginCommands = m_window->pluginCommands();
     for (const QVariant& item : pluginCommands) {
       QVariantMap entry = item.toMap();
-      entry["async"] = false;
-      entry["schema"] = QVariantMap();
       commands.append(entry);
     }
     std::sort(commands.begin(), commands.end(),
@@ -548,6 +568,13 @@ void RpcListener::messageReceived(const RPC::Message& message)
     QSize nativeSize;
     QImage image = m_window->renderToImage(requestedSize, transparentBackground,
                                            &nativeSize);
+    if (image.isNull()) {
+      // No active GL view, or the grab failed: there is nothing to save or
+      // encode, so report it rather than reply with a zero-sized image.
+      sendError(message, errorRequestFailed,
+                tr("Could not render the current view."));
+      return;
+    }
 
     if (!fileName.isEmpty()) {
       if (QFileInfo(fileName).suffix().isEmpty())
@@ -571,7 +598,11 @@ void RpcListener::messageReceived(const RPC::Message& message)
       QByteArray bytes;
       QBuffer buffer(&bytes);
       buffer.open(QIODevice::WriteOnly);
-      image.save(&buffer, "PNG");
+      if (!image.save(&buffer, "PNG")) {
+        sendError(message, errorRequestFailed,
+                  tr("Could not encode the render as PNG."));
+        return;
+      }
 
       QVariantMap result;
       result["width"] = image.width();

--- a/avogadro/rpclistener.cpp
+++ b/avogadro/rpclistener.cpp
@@ -89,7 +89,9 @@ const BuiltinCommand builtinCommands[] = {
   { "moleculeInfo", "Report summary statistics about the active molecule." },
   { "openFile", "Read a file from disk and make it the active molecule." },
   { "renderImage", "Render the current view to a PNG, inline or to a "
-                   "file." },
+                   "file. Omit width/height for the native framebuffer "
+                   "resolution, or supply both together to fit that "
+                   "render onto a canvas of exactly that size." },
   { "saveGraphic", "Render the current view and save it as an image at "
                    "the window's current size." },
   { "setProjection",
@@ -468,29 +470,45 @@ void RpcListener::messageReceived(const RPC::Message& message)
       }
     }
   } else if (method == "renderImage") {
-    const QSize defaultSize = m_window->activeViewSize();
-    int width = params.contains("width")
-                  ? params["width"].toInt(defaultSize.width())
-                  : defaultSize.width();
-    int height = params.contains("height")
-                   ? params["height"].toInt(defaultSize.height())
-                   : defaultSize.height();
-    width = qBound(1, width, 8192);
-    height = qBound(1, height, 8192);
+    // Width and height must be given together, or not at all: with only
+    // one of the two, there is no native size available yet (the grab
+    // hasn't happened) to derive the other from without rendering twice, so
+    // rather than guess an aspect ratio we reject the request outright.
+    const bool haveWidth = params.contains("width");
+    const bool haveHeight = params.contains("height");
+    if (haveWidth != haveHeight) {
+      sendError(message, errorRequestFailed,
+                tr("renderImage requires both width and height, or "
+                   "neither."));
+      return;
+    }
+
+    QSize requestedSize;
+    if (haveWidth && haveHeight) {
+      int width = qBound(1, params["width"].toInt(), 8192);
+      int height = qBound(1, params["height"].toInt(), 8192);
+      requestedSize = QSize(width, height);
+    }
+    // else: leave requestedSize null, so renderToImage() returns the
+    // native framebuffer grab untouched, at the maximum quality available.
+
     const bool transparentBackground =
       params["transparentBackground"].toBool(false);
     QString fileName = params["fileName"].toString();
 
-    QImage image =
-      m_window->renderToImage(QSize(width, height), transparentBackground);
+    QSize nativeSize;
+    QImage image = m_window->renderToImage(requestedSize, transparentBackground,
+                                           &nativeSize);
 
     if (!fileName.isEmpty()) {
       if (QFileInfo(fileName).suffix().isEmpty())
         fileName += ".png";
       if (image.save(fileName, "PNG")) {
         QVariantMap result;
-        result["width"] = width;
-        result["height"] = height;
+        result["width"] = image.width();
+        result["height"] = image.height();
+        result["nativeWidth"] = nativeSize.width();
+        result["nativeHeight"] = nativeSize.height();
         result["fileName"] = fileName;
 
         RPC::Message response = message.generateResponse();
@@ -507,8 +525,10 @@ void RpcListener::messageReceived(const RPC::Message& message)
       image.save(&buffer, "PNG");
 
       QVariantMap result;
-      result["width"] = width;
-      result["height"] = height;
+      result["width"] = image.width();
+      result["height"] = image.height();
+      result["nativeWidth"] = nativeSize.width();
+      result["nativeHeight"] = nativeSize.height();
       result["format"] = QStringLiteral("png");
       result["data"] = QString::fromLatin1(bytes.toBase64());
 

--- a/avogadro/rpclistener.h
+++ b/avogadro/rpclistener.h
@@ -40,7 +40,14 @@ class RpcListener : public QObject
   Q_OBJECT
 
 public:
-  explicit RpcListener(QObject* parent = nullptr);
+  /**
+   * @param connectionName The local socket name to listen on, so a headless
+   * instance can run beside a user's regular session. Defaults to
+   * "avogadro", matching every client that does not pass --rpc-name.
+   */
+  explicit RpcListener(
+    const QString& connectionName = QStringLiteral("avogadro"),
+    QObject* parent = nullptr);
   ~RpcListener() override;
 
   void start();


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RPC commands for retrieving application information, available commands, molecule data, display types, camera settings, and rendered images.
  * Added support for reading and updating camera settings through RPC.
  * Added a configurable RPC listener name via the `--rpc-name` command-line option.
  * Added optional waiting for export completion through RPC, including success, failure, and cancellation status.
  * Enhanced image rendering with configurable size, transparency, and native-resolution reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->